### PR TITLE
patch nodejs examples

### DIFF
--- a/sdk/nodejs/metal/device.ts
+++ b/sdk/nodejs/metal/device.ts
@@ -19,7 +19,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const web1 = new equinix.metal.Device("web1", {
  *     hostname: "tf.coreos2",
@@ -35,7 +35,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const pxe1 = new equinix.metal.Device("pxe1", {
  *     hostname: "tf.coreos2-pxe",
@@ -54,7 +54,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const web1 = new equinix.metal.Device("web1", {
  *     hostname: "tf.coreos2",
@@ -74,7 +74,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const web1 = new equinix.metal.Device("web1", {
  *     hostname: "tftest",

--- a/sdk/nodejs/metal/gateway.ts
+++ b/sdk/nodejs/metal/gateway.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create Metal Gateway for a VLAN with a private IPv4 block with 8 IP addresses
  * const testVlan = new equinix.metal.Vlan("testVlan", {
@@ -30,7 +30,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create Metal Gateway for a VLAN and reserved IP address block
  * const testVlan = new equinix.metal.Vlan("testVlan", {

--- a/sdk/nodejs/metal/getConnection.ts
+++ b/sdk/nodejs/metal/getConnection.ts
@@ -14,7 +14,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const example = pulumi.output(equinix.metal.getConnection({
  *     connectionId: "4347e805-eb46-4699-9eb9-5c116e6a017d",

--- a/sdk/nodejs/metal/getDevice.ts
+++ b/sdk/nodejs/metal/getDevice.ts
@@ -16,7 +16,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const test = equinix.metal.getDevice({
  *     projectId: local.project_id,
@@ -27,7 +27,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const test = equinix.metal.getDevice({
  *     deviceId: "4c641195-25e5-4c3c-b2b7-4cd7a42c7b40",

--- a/sdk/nodejs/metal/getDeviceBgpNeighbors.ts
+++ b/sdk/nodejs/metal/getDeviceBgpNeighbors.ts
@@ -18,7 +18,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const test = equinix.metal.getDeviceBgpNeighbors({
  *     deviceId: "4c641195-25e5-4c3c-b2b7-4cd7a42c7b40",

--- a/sdk/nodejs/metal/getGateway.ts
+++ b/sdk/nodejs/metal/getGateway.ts
@@ -13,8 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create Metal Gateway for a VLAN with a private IPv4 block with 8 IP addresses
  * const testVlan = new equinix.metal.Vlan("testVlan", {

--- a/sdk/nodejs/metal/getHardwareReservation.ts
+++ b/sdk/nodejs/metal/getHardwareReservation.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // lookup by ID
  * const example = pulumi.output(equinix.metal.getHardwareReservation({

--- a/sdk/nodejs/metal/getIpBlockRanges.ts
+++ b/sdk/nodejs/metal/getIpBlockRanges.ts
@@ -15,7 +15,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const projectId = "<UUID_of_your_project>";
  * const test = equinix.metal.getIpBlockRanges({

--- a/sdk/nodejs/metal/getOperatingSystem.ts
+++ b/sdk/nodejs/metal/getOperatingSystem.ts
@@ -11,8 +11,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const example = equinix.metal.getOperatingSystem({
  *     distro: "ubuntu",

--- a/sdk/nodejs/metal/getOrganization.ts
+++ b/sdk/nodejs/metal/getOrganization.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const test = equinix.metal.getOrganization({
  *     organizationId: local.org_id,

--- a/sdk/nodejs/metal/getPort.ts
+++ b/sdk/nodejs/metal/getPort.ts
@@ -14,8 +14,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const projectId = "<UUID_of_your_project>";
  * const testDevice = new equinix.metal.Device("testDevice", {

--- a/sdk/nodejs/metal/getProject.ts
+++ b/sdk/nodejs/metal/getProject.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const tfProject1 = equinix.metal.getProject({
  *     name: "Terraform Fun",

--- a/sdk/nodejs/metal/getProjectSshKey.ts
+++ b/sdk/nodejs/metal/getProjectSshKey.ts
@@ -11,7 +11,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const myKey = equinix.metal.getProjectSshKey({
  *     search: "username@hostname",

--- a/sdk/nodejs/metal/getSpotMarketPrice.ts
+++ b/sdk/nodejs/metal/getSpotMarketPrice.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const example = pulumi.output(equinix.metal.getSpotMarketPrice({
  *     facility: "ny5",
@@ -25,7 +25,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const example = pulumi.output(equinix.metal.getSpotMarketPrice({
  *     metro: "sv",

--- a/sdk/nodejs/metal/getVirtualCircuit.ts
+++ b/sdk/nodejs/metal/getVirtualCircuit.ts
@@ -14,7 +14,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const exampleConnection = equinix.metal.getConnection({
  *     connectionId: "4347e805-eb46-4699-9eb9-5c116e6a017d",

--- a/sdk/nodejs/metal/getVlan.ts
+++ b/sdk/nodejs/metal/getVlan.ts
@@ -14,8 +14,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const foovlan = new equinix.metal.Vlan("foovlan", {
  *     projectId: local.project_id,
@@ -31,7 +30,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const dsvlan = equinix.metal.getVlan({
  *     projectId: local.project_id,

--- a/sdk/nodejs/metal/getVrf.ts
+++ b/sdk/nodejs/metal/getVrf.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const exampleVrf = pulumi.output(equinix.metal.getVrf({
  *     vrfId: "48630899-9ff2-4ce6-a93f-50ff4ebcdf6e",

--- a/sdk/nodejs/metal/organization.ts
+++ b/sdk/nodejs/metal/organization.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create a new Organization
  * const tfOrganization1 = new equinix.metal.Organization("tf_organization_1", {

--- a/sdk/nodejs/metal/organizationMember.ts
+++ b/sdk/nodejs/metal/organizationMember.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const member = new equinix.metal.OrganizationMember("member", {
  *     invitee: "member@example.com",
@@ -27,7 +27,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const owner = new equinix.metal.OrganizationMember("owner", {
  *     invitee: "admin@example.com",

--- a/sdk/nodejs/metal/portVlanAttachment.ts
+++ b/sdk/nodejs/metal/portVlanAttachment.ts
@@ -21,7 +21,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const testVlan = new equinix.metal.Vlan("testVlan", {
  *     description: "VLAN in New Jersey",
@@ -50,7 +50,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const testDevice = new equinix.metal.Device("testDevice", {
  *     hostname: "test",

--- a/sdk/nodejs/metal/projectApiKey.ts
+++ b/sdk/nodejs/metal/projectApiKey.ts
@@ -16,7 +16,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create a new read-only API key in existing project
  * const test = new equinix.metal.ProjectApiKey("test", {

--- a/sdk/nodejs/metal/projectSshKey.ts
+++ b/sdk/nodejs/metal/projectSshKey.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const projectId = "<UUID_of_your_project>";
  * const testProjectSshKey = new equinix.metal.ProjectSshKey("testProjectSshKey", {

--- a/sdk/nodejs/metal/reservedIpBlock.ts
+++ b/sdk/nodejs/metal/reservedIpBlock.ts
@@ -27,7 +27,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Allocate /31 block of max 2 public IPv4 addresses in Silicon Valley (sv15) facility for myproject
  * const twoElasticAddresses = new equinix.metal.ReservedIpBlock("twoElasticAddresses", {
@@ -54,7 +54,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Allocate /31 block of max 2 public IPv4 addresses in Silicon Valley (sv15) facility
  * const example = new equinix.metal.ReservedIpBlock("example", {

--- a/sdk/nodejs/metal/spotMarketRequest.ts
+++ b/sdk/nodejs/metal/spotMarketRequest.ts
@@ -14,7 +14,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create a spot market request
  * const req = new equinix.metal.SpotMarketRequest("req", {

--- a/sdk/nodejs/metal/sshKey.ts
+++ b/sdk/nodejs/metal/sshKey.ts
@@ -14,7 +14,7 @@ import * as utilities from "../utilities";
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
  * import * as fs from "fs";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create a new SSH key
  * const key1 = new equinix.metal.SshKey("key1", {publicKey: fs.readFileSync("/home/terraform/.ssh/id_rsa.pub")});

--- a/sdk/nodejs/metal/userApiKey.ts
+++ b/sdk/nodejs/metal/userApiKey.ts
@@ -16,7 +16,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const test = new equinix.metal.UserApiKey("test", {
  *     description: "Read-only user key",

--- a/sdk/nodejs/metal/virtualCircuit.ts
+++ b/sdk/nodejs/metal/virtualCircuit.ts
@@ -17,8 +17,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const projectId = "52000fb2-ee46-4673-93a8-de2c2bdba33c";
  * const connId = "73f12f29-3e19-43a0-8e90-ae81580db1e0";

--- a/sdk/nodejs/metal/vlan.ts
+++ b/sdk/nodejs/metal/vlan.ts
@@ -17,7 +17,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create a new VLAN in facility "sv15"
  * const vlan1Vlan = new equinix.metal.Vlan("vlan1Vlan", {

--- a/sdk/nodejs/metal/vrf.ts
+++ b/sdk/nodejs/metal/vrf.ts
@@ -15,7 +15,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const exampleProject = new equinix.metal.Project("exampleProject", {});
  * const exampleVrf = new equinix.metal.Vrf("exampleVrf", {
@@ -34,7 +34,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const exampleReservedIpBlock = new equinix.metal.ReservedIpBlock("exampleReservedIpBlock", {
  *     description: "Reserved IP block (192.168.100.0/29) taken from on of the ranges in the VRF's pool of address space.",
@@ -61,8 +61,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const exampleConnection = equinix.metal.getConnection({
  *     connectionId: _var.metal_dedicated_connection_id,

--- a/sdk/nodejs/networkedge/aclTemplate.ts
+++ b/sdk/nodejs/networkedge/aclTemplate.ts
@@ -16,7 +16,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Creates ACL template and assigns it to the network device
  * const myacl = new equinix.networkedge.AclTemplate("myacl", {

--- a/sdk/nodejs/networkedge/bgp.ts
+++ b/sdk/nodejs/networkedge/bgp.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const test = new equinix.networkedge.Bgp("test", {
  *     authenticationKey: "secret",

--- a/sdk/nodejs/networkedge/device.ts
+++ b/sdk/nodejs/networkedge/device.ts
@@ -28,8 +28,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const dc = equinix.networkedge.getAccount({
  *     metroCode: "DC",
@@ -68,8 +67,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const sv = equinix.networkedge.getAccount({
  *     metroCode: "SV",

--- a/sdk/nodejs/networkedge/deviceLink.ts
+++ b/sdk/nodejs/networkedge/deviceLink.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Example of device link with HA device pair
  * // where each device is in different metro

--- a/sdk/nodejs/networkedge/getAccount.ts
+++ b/sdk/nodejs/networkedge/getAccount.ts
@@ -15,7 +15,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * const dc = equinix.networkedge.getAccount({
  *     metroCode: "DC",

--- a/sdk/nodejs/networkedge/getDevice.ts
+++ b/sdk/nodejs/networkedge/getDevice.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Retrieve data for an existing Equinix Network Edge device with UUID "f0b5c553-cdeb-4bc3-95b8-23db9ccfd5ee"
  * const byUuid = pulumi.output(equinix.networkedge.getDevice({

--- a/sdk/nodejs/networkedge/getDevicePlatform.ts
+++ b/sdk/nodejs/networkedge/getDevicePlatform.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Retrieve platform configuration of a large flavor for a CSR100V device type
  * // Platform has to support IPBASE software package

--- a/sdk/nodejs/networkedge/getDeviceSoftware.ts
+++ b/sdk/nodejs/networkedge/getDeviceSoftware.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Retrieve details for CSR1000V device software with latest path of 16.09 version
  * // that supports IPBASE package

--- a/sdk/nodejs/networkedge/getDeviceType.ts
+++ b/sdk/nodejs/networkedge/getDeviceType.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as equinix from "@pulumi/equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Retrieve device type details of a Cisco router
  * // Device type has to be available in DC and SV metros

--- a/sdk/nodejs/networkedge/sshUser.ts
+++ b/sdk/nodejs/networkedge/sshUser.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  *
  * ```typescript
  * import * as pulumi from "@pulumi/pulumi";
- * import * as pulumi_equinix from "@equinix/pulumi-equinix";
+ * import * as equinix from "@equinix/pulumi-equinix";
  *
  * // Create SSH user with password auth method and associate it with
  * // two virtual network devices


### PR DESCRIPTION
The generated examples (imported from terraform) are using a wrong package assuming in some cases that it belongs to the organization `pulumi`. In some cases it imports it correctly but then references it with `equinix` instead of the generated alias `pulumi_equinix`. Identifying/fix this error in the pulumi code is quite complex, because as I explained, it doesn't even act uniformly, so patching them is a short-term solution.

Many of these examples are not even being generated for other SDKs and at the moment it seems that it would be better to use overlays for these, and be able to continue taking advantage of the terraform bridge, instead of creating a native provider. I will open a new issue to work on improving the examples / documentation, but them aren't mandatory for a first release