### PR TITLE
fix: add newlines before closing shortcode in BGP session examples

### DIFF
--- a/docs/resource/equinix_metal_bgp_session.examples.md
+++ b/docs/resource/equinix_metal_bgp_session.examples.md
@@ -107,5 +107,5 @@ resources:
       addressFamily: ipv4
 outputs:
   bgpSessionStatus: ${bgp.status}
-```{{% /example %}}
-
+```
+{{% /example %}}


### PR DESCRIPTION
Closes #10 