### PR TITLE
Fix upstream to tag

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -402,6 +402,8 @@ github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy0
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/envoyproxy/go-control-plane v0.11.1-0.20230524094728-9239064ad72f h1:7T++XKzy4xg7PKy+bM+Sa9/oe1OC88yz2hXQUISoXfA=
 github.com/envoyproxy/protoc-gen-validate v0.10.1 h1:c0g45+xCJhdgFGw7a5QAfdS4byAbud7miNWJ1WwEVf8=
+github.com/equinix-labs/metal-go v0.25.1 h1:uL83lRKyAcOfab+9r2xujAuLD8lTsqv89+SPvVFkcBM=
+github.com/equinix-labs/metal-go v0.25.1/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch/v5 v5.5.0 h1:bAmFiUJ+o0o2B4OiTFeE3MqCOtyo+jjPP9iZ0VRxYUc=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=

--- a/provider/cmd/pulumi-resource-equinix/schema.json
+++ b/provider/cmd/pulumi-resource-equinix/schema.json
@@ -9706,11 +9706,8 @@
                     "$ref": "#/types/equinix:fabric/CloudRouterPackage:CloudRouterPackage",
                     "description": "Fabric Cloud Router package\n"
                 },
-                "projects": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/types/equinix:fabric/CloudRouterProject:CloudRouterProject"
-                    },
+                "project": {
+                    "$ref": "#/types/equinix:fabric/CloudRouterProject:CloudRouterProject",
                     "description": "Fabric Cloud Router project\n"
                 },
                 "state": {
@@ -9765,11 +9762,8 @@
                     "$ref": "#/types/equinix:fabric/CloudRouterPackage:CloudRouterPackage",
                     "description": "Fabric Cloud Router package\n"
                 },
-                "projects": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/types/equinix:fabric/CloudRouterProject:CloudRouterProject"
-                    },
+                "project": {
+                    "$ref": "#/types/equinix:fabric/CloudRouterProject:CloudRouterProject",
                     "description": "Fabric Cloud Router project\n"
                 },
                 "type": {
@@ -9832,11 +9826,8 @@
                         "$ref": "#/types/equinix:fabric/CloudRouterPackage:CloudRouterPackage",
                         "description": "Fabric Cloud Router package\n"
                     },
-                    "projects": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/types/equinix:fabric/CloudRouterProject:CloudRouterProject"
-                        },
+                    "project": {
+                        "$ref": "#/types/equinix:fabric/CloudRouterProject:CloudRouterProject",
                         "description": "Fabric Cloud Router project\n"
                     },
                     "state": {

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	github.com/equinix/terraform-provider-equinix v1.18.2
+	github.com/equinix/terraform-provider-equinix v1.19.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.63.2
 	github.com/pulumi/pulumi/pkg/v3 v3.91.1
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1
@@ -82,7 +82,7 @@ require (
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/equinix-labs/fabric-go v0.7.0 // indirect
-	github.com/equinix-labs/metal-go v0.16.0 // indirect
+	github.com/equinix-labs/metal-go v0.25.1 // indirect
 	github.com/equinix/ecx-go/v2 v2.3.1 // indirect
 	github.com/equinix/ne-go v1.11.0 // indirect
 	github.com/equinix/oauth2-go v1.0.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1166,8 +1166,8 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/equinix-labs/fabric-go v0.7.0 h1:AiiVPD4aE/aeiuCK7Fhsq4bvjmJ5RzmZ3boKnp0dl4g=
 github.com/equinix-labs/fabric-go v0.7.0/go.mod h1:oqgGS3GOI8hHGPJKsAwDOEX0qRHl52sJGvwA/zMSd90=
-github.com/equinix-labs/metal-go v0.16.0 h1:4YmGx9SRFkDtHiEqRsSjlgJDztV6NHqH1eeaOZcK7d4=
-github.com/equinix-labs/metal-go v0.16.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.25.1 h1:uL83lRKyAcOfab+9r2xujAuLD8lTsqv89+SPvVFkcBM=
+github.com/equinix-labs/metal-go v0.25.1/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/equinix/ecx-go/v2 v2.3.1 h1:gFcAIeyaEUw7S8ebqApmT7E/S7pC7Ac3wgScp89fkPU=
 github.com/equinix/ecx-go/v2 v2.3.1/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
 github.com/equinix/ne-go v1.11.0 h1:ja6G2fmcGrLsOeV25Mq6pDfH+/cUlvxJbnE8uRXTGGk=

--- a/sdk/dotnet/Fabric/CloudRouter.cs
+++ b/sdk/dotnet/Fabric/CloudRouter.cs
@@ -124,8 +124,8 @@ namespace Pulumi.Equinix.Fabric
         /// <summary>
         /// Fabric Cloud Router project
         /// </summary>
-        [Output("projects")]
-        public Output<ImmutableArray<Outputs.CloudRouterProject>> Projects { get; private set; } = null!;
+        [Output("project")]
+        public Output<Outputs.CloudRouterProject?> Project { get; private set; } = null!;
 
         /// <summary>
         /// Fabric Cloud Router overall state
@@ -234,17 +234,11 @@ namespace Pulumi.Equinix.Fabric
         [Input("package", required: true)]
         public Input<Inputs.CloudRouterPackageArgs> Package { get; set; } = null!;
 
-        [Input("projects")]
-        private InputList<Inputs.CloudRouterProjectArgs>? _projects;
-
         /// <summary>
         /// Fabric Cloud Router project
         /// </summary>
-        public InputList<Inputs.CloudRouterProjectArgs> Projects
-        {
-            get => _projects ?? (_projects = new InputList<Inputs.CloudRouterProjectArgs>());
-            set => _projects = value;
-        }
+        [Input("project")]
+        public Input<Inputs.CloudRouterProjectArgs>? Project { get; set; }
 
         /// <summary>
         /// Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
@@ -332,17 +326,11 @@ namespace Pulumi.Equinix.Fabric
         [Input("package")]
         public Input<Inputs.CloudRouterPackageGetArgs>? Package { get; set; }
 
-        [Input("projects")]
-        private InputList<Inputs.CloudRouterProjectGetArgs>? _projects;
-
         /// <summary>
         /// Fabric Cloud Router project
         /// </summary>
-        public InputList<Inputs.CloudRouterProjectGetArgs> Projects
-        {
-            get => _projects ?? (_projects = new InputList<Inputs.CloudRouterProjectGetArgs>());
-            set => _projects = value;
-        }
+        [Input("project")]
+        public Input<Inputs.CloudRouterProjectGetArgs>? Project { get; set; }
 
         /// <summary>
         /// Fabric Cloud Router overall state

--- a/sdk/go/equinix/fabric/cloudRouter.go
+++ b/sdk/go/equinix/fabric/cloudRouter.go
@@ -87,7 +87,7 @@ type CloudRouter struct {
 	// Fabric Cloud Router package
 	Package CloudRouterPackageOutput `pulumi:"package"`
 	// Fabric Cloud Router project
-	Projects CloudRouterProjectArrayOutput `pulumi:"projects"`
+	Project CloudRouterProjectPtrOutput `pulumi:"project"`
 	// Fabric Cloud Router overall state
 	State pulumi.StringOutput `pulumi:"state"`
 	// Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
@@ -157,7 +157,7 @@ type cloudRouterState struct {
 	// Fabric Cloud Router package
 	Package *CloudRouterPackage `pulumi:"package"`
 	// Fabric Cloud Router project
-	Projects []CloudRouterProject `pulumi:"projects"`
+	Project *CloudRouterProject `pulumi:"project"`
 	// Fabric Cloud Router overall state
 	State *string `pulumi:"state"`
 	// Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
@@ -186,7 +186,7 @@ type CloudRouterState struct {
 	// Fabric Cloud Router package
 	Package CloudRouterPackagePtrInput
 	// Fabric Cloud Router project
-	Projects CloudRouterProjectArrayInput
+	Project CloudRouterProjectPtrInput
 	// Fabric Cloud Router overall state
 	State pulumi.StringPtrInput
 	// Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
@@ -213,7 +213,7 @@ type cloudRouterArgs struct {
 	// Fabric Cloud Router package
 	Package CloudRouterPackage `pulumi:"package"`
 	// Fabric Cloud Router project
-	Projects []CloudRouterProject `pulumi:"projects"`
+	Project *CloudRouterProject `pulumi:"project"`
 	// Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
 	Type string `pulumi:"type"`
 }
@@ -235,7 +235,7 @@ type CloudRouterArgs struct {
 	// Fabric Cloud Router package
 	Package CloudRouterPackageInput
 	// Fabric Cloud Router project
-	Projects CloudRouterProjectArrayInput
+	Project CloudRouterProjectPtrInput
 	// Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
 	Type pulumi.StringInput
 }
@@ -402,8 +402,8 @@ func (o CloudRouterOutput) Package() CloudRouterPackageOutput {
 }
 
 // Fabric Cloud Router project
-func (o CloudRouterOutput) Projects() CloudRouterProjectArrayOutput {
-	return o.ApplyT(func(v *CloudRouter) CloudRouterProjectArrayOutput { return v.Projects }).(CloudRouterProjectArrayOutput)
+func (o CloudRouterOutput) Project() CloudRouterProjectPtrOutput {
+	return o.ApplyT(func(v *CloudRouter) CloudRouterProjectPtrOutput { return v.Project }).(CloudRouterProjectPtrOutput)
 }
 
 // Fabric Cloud Router overall state

--- a/sdk/go/equinix/fabric/pulumiTypes.go
+++ b/sdk/go/equinix/fabric/pulumiTypes.go
@@ -1139,34 +1139,50 @@ func (i CloudRouterProjectArgs) ToOutput(ctx context.Context) pulumix.Output[Clo
 	}
 }
 
-// CloudRouterProjectArrayInput is an input type that accepts CloudRouterProjectArray and CloudRouterProjectArrayOutput values.
-// You can construct a concrete instance of `CloudRouterProjectArrayInput` via:
+func (i CloudRouterProjectArgs) ToCloudRouterProjectPtrOutput() CloudRouterProjectPtrOutput {
+	return i.ToCloudRouterProjectPtrOutputWithContext(context.Background())
+}
+
+func (i CloudRouterProjectArgs) ToCloudRouterProjectPtrOutputWithContext(ctx context.Context) CloudRouterProjectPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(CloudRouterProjectOutput).ToCloudRouterProjectPtrOutputWithContext(ctx)
+}
+
+// CloudRouterProjectPtrInput is an input type that accepts CloudRouterProjectArgs, CloudRouterProjectPtr and CloudRouterProjectPtrOutput values.
+// You can construct a concrete instance of `CloudRouterProjectPtrInput` via:
 //
-//	CloudRouterProjectArray{ CloudRouterProjectArgs{...} }
-type CloudRouterProjectArrayInput interface {
+//	        CloudRouterProjectArgs{...}
+//
+//	or:
+//
+//	        nil
+type CloudRouterProjectPtrInput interface {
 	pulumi.Input
 
-	ToCloudRouterProjectArrayOutput() CloudRouterProjectArrayOutput
-	ToCloudRouterProjectArrayOutputWithContext(context.Context) CloudRouterProjectArrayOutput
+	ToCloudRouterProjectPtrOutput() CloudRouterProjectPtrOutput
+	ToCloudRouterProjectPtrOutputWithContext(context.Context) CloudRouterProjectPtrOutput
 }
 
-type CloudRouterProjectArray []CloudRouterProjectInput
+type cloudRouterProjectPtrType CloudRouterProjectArgs
 
-func (CloudRouterProjectArray) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]CloudRouterProject)(nil)).Elem()
+func CloudRouterProjectPtr(v *CloudRouterProjectArgs) CloudRouterProjectPtrInput {
+	return (*cloudRouterProjectPtrType)(v)
 }
 
-func (i CloudRouterProjectArray) ToCloudRouterProjectArrayOutput() CloudRouterProjectArrayOutput {
-	return i.ToCloudRouterProjectArrayOutputWithContext(context.Background())
+func (*cloudRouterProjectPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**CloudRouterProject)(nil)).Elem()
 }
 
-func (i CloudRouterProjectArray) ToCloudRouterProjectArrayOutputWithContext(ctx context.Context) CloudRouterProjectArrayOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(CloudRouterProjectArrayOutput)
+func (i *cloudRouterProjectPtrType) ToCloudRouterProjectPtrOutput() CloudRouterProjectPtrOutput {
+	return i.ToCloudRouterProjectPtrOutputWithContext(context.Background())
 }
 
-func (i CloudRouterProjectArray) ToOutput(ctx context.Context) pulumix.Output[[]CloudRouterProject] {
-	return pulumix.Output[[]CloudRouterProject]{
-		OutputState: i.ToCloudRouterProjectArrayOutputWithContext(ctx).OutputState,
+func (i *cloudRouterProjectPtrType) ToCloudRouterProjectPtrOutputWithContext(ctx context.Context) CloudRouterProjectPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(CloudRouterProjectPtrOutput)
+}
+
+func (i *cloudRouterProjectPtrType) ToOutput(ctx context.Context) pulumix.Output[*CloudRouterProject] {
+	return pulumix.Output[*CloudRouterProject]{
+		OutputState: i.ToCloudRouterProjectPtrOutputWithContext(ctx).OutputState,
 	}
 }
 
@@ -1182,6 +1198,16 @@ func (o CloudRouterProjectOutput) ToCloudRouterProjectOutput() CloudRouterProjec
 
 func (o CloudRouterProjectOutput) ToCloudRouterProjectOutputWithContext(ctx context.Context) CloudRouterProjectOutput {
 	return o
+}
+
+func (o CloudRouterProjectOutput) ToCloudRouterProjectPtrOutput() CloudRouterProjectPtrOutput {
+	return o.ToCloudRouterProjectPtrOutputWithContext(context.Background())
+}
+
+func (o CloudRouterProjectOutput) ToCloudRouterProjectPtrOutputWithContext(ctx context.Context) CloudRouterProjectPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v CloudRouterProject) *CloudRouterProject {
+		return &v
+	}).(CloudRouterProjectPtrOutput)
 }
 
 func (o CloudRouterProjectOutput) ToOutput(ctx context.Context) pulumix.Output[CloudRouterProject] {
@@ -1200,30 +1226,54 @@ func (o CloudRouterProjectOutput) ProjectId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v CloudRouterProject) *string { return v.ProjectId }).(pulumi.StringPtrOutput)
 }
 
-type CloudRouterProjectArrayOutput struct{ *pulumi.OutputState }
+type CloudRouterProjectPtrOutput struct{ *pulumi.OutputState }
 
-func (CloudRouterProjectArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]CloudRouterProject)(nil)).Elem()
+func (CloudRouterProjectPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**CloudRouterProject)(nil)).Elem()
 }
 
-func (o CloudRouterProjectArrayOutput) ToCloudRouterProjectArrayOutput() CloudRouterProjectArrayOutput {
+func (o CloudRouterProjectPtrOutput) ToCloudRouterProjectPtrOutput() CloudRouterProjectPtrOutput {
 	return o
 }
 
-func (o CloudRouterProjectArrayOutput) ToCloudRouterProjectArrayOutputWithContext(ctx context.Context) CloudRouterProjectArrayOutput {
+func (o CloudRouterProjectPtrOutput) ToCloudRouterProjectPtrOutputWithContext(ctx context.Context) CloudRouterProjectPtrOutput {
 	return o
 }
 
-func (o CloudRouterProjectArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]CloudRouterProject] {
-	return pulumix.Output[[]CloudRouterProject]{
+func (o CloudRouterProjectPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*CloudRouterProject] {
+	return pulumix.Output[*CloudRouterProject]{
 		OutputState: o.OutputState,
 	}
 }
 
-func (o CloudRouterProjectArrayOutput) Index(i pulumi.IntInput) CloudRouterProjectOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) CloudRouterProject {
-		return vs[0].([]CloudRouterProject)[vs[1].(int)]
+func (o CloudRouterProjectPtrOutput) Elem() CloudRouterProjectOutput {
+	return o.ApplyT(func(v *CloudRouterProject) CloudRouterProject {
+		if v != nil {
+			return *v
+		}
+		var ret CloudRouterProject
+		return ret
 	}).(CloudRouterProjectOutput)
+}
+
+// Unique Resource URL
+func (o CloudRouterProjectPtrOutput) Href() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *CloudRouterProject) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Href
+	}).(pulumi.StringPtrOutput)
+}
+
+// Project Id
+func (o CloudRouterProjectPtrOutput) ProjectId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *CloudRouterProject) *string {
+		if v == nil {
+			return nil
+		}
+		return v.ProjectId
+	}).(pulumi.StringPtrOutput)
 }
 
 type ConnectionASide struct {
@@ -29834,7 +29884,7 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*CloudRouterPackageInput)(nil)).Elem(), CloudRouterPackageArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*CloudRouterPackagePtrInput)(nil)).Elem(), CloudRouterPackageArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*CloudRouterProjectInput)(nil)).Elem(), CloudRouterProjectArgs{})
-	pulumi.RegisterInputType(reflect.TypeOf((*CloudRouterProjectArrayInput)(nil)).Elem(), CloudRouterProjectArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CloudRouterProjectPtrInput)(nil)).Elem(), CloudRouterProjectArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ConnectionASideInput)(nil)).Elem(), ConnectionASideArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ConnectionASidePtrInput)(nil)).Elem(), ConnectionASideArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ConnectionASideAccessPointInput)(nil)).Elem(), ConnectionASideAccessPointArgs{})
@@ -30184,7 +30234,7 @@ func init() {
 	pulumi.RegisterOutputType(CloudRouterPackageOutput{})
 	pulumi.RegisterOutputType(CloudRouterPackagePtrOutput{})
 	pulumi.RegisterOutputType(CloudRouterProjectOutput{})
-	pulumi.RegisterOutputType(CloudRouterProjectArrayOutput{})
+	pulumi.RegisterOutputType(CloudRouterProjectPtrOutput{})
 	pulumi.RegisterOutputType(ConnectionASideOutput{})
 	pulumi.RegisterOutputType(ConnectionASidePtrOutput{})
 	pulumi.RegisterOutputType(ConnectionASideAccessPointOutput{})

--- a/sdk/java/src/main/java/com/equinix/pulumi/fabric/CloudRouter.java
+++ b/sdk/java/src/main/java/com/equinix/pulumi/fabric/CloudRouter.java
@@ -223,15 +223,15 @@ public class CloudRouter extends com.pulumi.resources.CustomResource {
      * Fabric Cloud Router project
      * 
      */
-    @Export(name="projects", refs={List.class,CloudRouterProject.class}, tree="[0,1]")
-    private Output</* @Nullable */ List<CloudRouterProject>> projects;
+    @Export(name="project", refs={CloudRouterProject.class}, tree="[0]")
+    private Output</* @Nullable */ CloudRouterProject> project;
 
     /**
      * @return Fabric Cloud Router project
      * 
      */
-    public Output<Optional<List<CloudRouterProject>>> projects() {
-        return Codegen.optional(this.projects);
+    public Output<Optional<CloudRouterProject>> project() {
+        return Codegen.optional(this.project);
     }
     /**
      * Fabric Cloud Router overall state

--- a/sdk/java/src/main/java/com/equinix/pulumi/fabric/CloudRouterArgs.java
+++ b/sdk/java/src/main/java/com/equinix/pulumi/fabric/CloudRouterArgs.java
@@ -131,15 +131,15 @@ public final class CloudRouterArgs extends com.pulumi.resources.ResourceArgs {
      * Fabric Cloud Router project
      * 
      */
-    @Import(name="projects")
-    private @Nullable Output<List<CloudRouterProjectArgs>> projects;
+    @Import(name="project")
+    private @Nullable Output<CloudRouterProjectArgs> project;
 
     /**
      * @return Fabric Cloud Router project
      * 
      */
-    public Optional<Output<List<CloudRouterProjectArgs>>> projects() {
-        return Optional.ofNullable(this.projects);
+    public Optional<Output<CloudRouterProjectArgs>> project() {
+        return Optional.ofNullable(this.project);
     }
 
     /**
@@ -167,7 +167,7 @@ public final class CloudRouterArgs extends com.pulumi.resources.ResourceArgs {
         this.notifications = $.notifications;
         this.order = $.order;
         this.package_ = $.package_;
-        this.projects = $.projects;
+        this.project = $.project;
         this.type = $.type;
     }
 
@@ -347,34 +347,24 @@ public final class CloudRouterArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param projects Fabric Cloud Router project
+         * @param project Fabric Cloud Router project
          * 
          * @return builder
          * 
          */
-        public Builder projects(@Nullable Output<List<CloudRouterProjectArgs>> projects) {
-            $.projects = projects;
+        public Builder project(@Nullable Output<CloudRouterProjectArgs> project) {
+            $.project = project;
             return this;
         }
 
         /**
-         * @param projects Fabric Cloud Router project
+         * @param project Fabric Cloud Router project
          * 
          * @return builder
          * 
          */
-        public Builder projects(List<CloudRouterProjectArgs> projects) {
-            return projects(Output.of(projects));
-        }
-
-        /**
-         * @param projects Fabric Cloud Router project
-         * 
-         * @return builder
-         * 
-         */
-        public Builder projects(CloudRouterProjectArgs... projects) {
-            return projects(List.of(projects));
+        public Builder project(CloudRouterProjectArgs project) {
+            return project(Output.of(project));
         }
 
         /**

--- a/sdk/java/src/main/java/com/equinix/pulumi/fabric/inputs/CloudRouterState.java
+++ b/sdk/java/src/main/java/com/equinix/pulumi/fabric/inputs/CloudRouterState.java
@@ -178,15 +178,15 @@ public final class CloudRouterState extends com.pulumi.resources.ResourceArgs {
      * Fabric Cloud Router project
      * 
      */
-    @Import(name="projects")
-    private @Nullable Output<List<CloudRouterProjectArgs>> projects;
+    @Import(name="project")
+    private @Nullable Output<CloudRouterProjectArgs> project;
 
     /**
      * @return Fabric Cloud Router project
      * 
      */
-    public Optional<Output<List<CloudRouterProjectArgs>>> projects() {
-        return Optional.ofNullable(this.projects);
+    public Optional<Output<CloudRouterProjectArgs>> project() {
+        return Optional.ofNullable(this.project);
     }
 
     /**
@@ -232,7 +232,7 @@ public final class CloudRouterState extends com.pulumi.resources.ResourceArgs {
         this.notifications = $.notifications;
         this.order = $.order;
         this.package_ = $.package_;
-        this.projects = $.projects;
+        this.project = $.project;
         this.state = $.state;
         this.type = $.type;
     }
@@ -486,34 +486,24 @@ public final class CloudRouterState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param projects Fabric Cloud Router project
+         * @param project Fabric Cloud Router project
          * 
          * @return builder
          * 
          */
-        public Builder projects(@Nullable Output<List<CloudRouterProjectArgs>> projects) {
-            $.projects = projects;
+        public Builder project(@Nullable Output<CloudRouterProjectArgs> project) {
+            $.project = project;
             return this;
         }
 
         /**
-         * @param projects Fabric Cloud Router project
+         * @param project Fabric Cloud Router project
          * 
          * @return builder
          * 
          */
-        public Builder projects(List<CloudRouterProjectArgs> projects) {
-            return projects(Output.of(projects));
-        }
-
-        /**
-         * @param projects Fabric Cloud Router project
-         * 
-         * @return builder
-         * 
-         */
-        public Builder projects(CloudRouterProjectArgs... projects) {
-            return projects(List.of(projects));
+        public Builder project(CloudRouterProjectArgs project) {
+            return project(Output.of(project));
         }
 
         /**

--- a/sdk/nodejs/fabric/cloudRouter.ts
+++ b/sdk/nodejs/fabric/cloudRouter.ts
@@ -108,7 +108,7 @@ export class CloudRouter extends pulumi.CustomResource {
     /**
      * Fabric Cloud Router project
      */
-    public readonly projects!: pulumi.Output<outputs.fabric.CloudRouterProject[] | undefined>;
+    public readonly project!: pulumi.Output<outputs.fabric.CloudRouterProject | undefined>;
     /**
      * Fabric Cloud Router overall state
      */
@@ -141,7 +141,7 @@ export class CloudRouter extends pulumi.CustomResource {
             resourceInputs["notifications"] = state ? state.notifications : undefined;
             resourceInputs["order"] = state ? state.order : undefined;
             resourceInputs["package"] = state ? state.package : undefined;
-            resourceInputs["projects"] = state ? state.projects : undefined;
+            resourceInputs["project"] = state ? state.project : undefined;
             resourceInputs["state"] = state ? state.state : undefined;
             resourceInputs["type"] = state ? state.type : undefined;
         } else {
@@ -165,7 +165,7 @@ export class CloudRouter extends pulumi.CustomResource {
             resourceInputs["notifications"] = args ? args.notifications : undefined;
             resourceInputs["order"] = args ? args.order : undefined;
             resourceInputs["package"] = args ? args.package : undefined;
-            resourceInputs["projects"] = args ? args.projects : undefined;
+            resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
             resourceInputs["changeLogs"] = undefined /*out*/;
             resourceInputs["equinixAsn"] = undefined /*out*/;
@@ -224,7 +224,7 @@ export interface CloudRouterState {
     /**
      * Fabric Cloud Router project
      */
-    projects?: pulumi.Input<pulumi.Input<inputs.fabric.CloudRouterProject>[]>;
+    project?: pulumi.Input<inputs.fabric.CloudRouterProject>;
     /**
      * Fabric Cloud Router overall state
      */
@@ -270,7 +270,7 @@ export interface CloudRouterArgs {
     /**
      * Fabric Cloud Router project
      */
-    projects?: pulumi.Input<pulumi.Input<inputs.fabric.CloudRouterProject>[]>;
+    project?: pulumi.Input<inputs.fabric.CloudRouterProject>;
     /**
      * Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
      */

--- a/sdk/python/pulumi_equinix/fabric/cloud_router.py
+++ b/sdk/python/pulumi_equinix/fabric/cloud_router.py
@@ -24,7 +24,7 @@ class CloudRouterArgs:
                  description: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  order: Optional[pulumi.Input['CloudRouterOrderArgs']] = None,
-                 projects: Optional[pulumi.Input[Sequence[pulumi.Input['CloudRouterProjectArgs']]]] = None):
+                 project: Optional[pulumi.Input['CloudRouterProjectArgs']] = None):
         """
         The set of arguments for constructing a CloudRouter resource.
         :param pulumi.Input['CloudRouterLocationArgs'] location: Fabric Cloud Router location
@@ -35,7 +35,7 @@ class CloudRouterArgs:
         :param pulumi.Input[str] description: Customer-provided Fabric Cloud Router description
         :param pulumi.Input[str] name: Fabric Cloud Router name. An alpha-numeric 24 characters string which can include only hyphens and underscores
         :param pulumi.Input['CloudRouterOrderArgs'] order: Order information related to this Fabric Cloud Router
-        :param pulumi.Input[Sequence[pulumi.Input['CloudRouterProjectArgs']]] projects: Fabric Cloud Router project
+        :param pulumi.Input['CloudRouterProjectArgs'] project: Fabric Cloud Router project
         """
         pulumi.set(__self__, "location", location)
         pulumi.set(__self__, "notifications", notifications)
@@ -49,8 +49,8 @@ class CloudRouterArgs:
             pulumi.set(__self__, "name", name)
         if order is not None:
             pulumi.set(__self__, "order", order)
-        if projects is not None:
-            pulumi.set(__self__, "projects", projects)
+        if project is not None:
+            pulumi.set(__self__, "project", project)
 
     @property
     @pulumi.getter
@@ -150,15 +150,15 @@ class CloudRouterArgs:
 
     @property
     @pulumi.getter
-    def projects(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['CloudRouterProjectArgs']]]]:
+    def project(self) -> Optional[pulumi.Input['CloudRouterProjectArgs']]:
         """
         Fabric Cloud Router project
         """
-        return pulumi.get(self, "projects")
+        return pulumi.get(self, "project")
 
-    @projects.setter
-    def projects(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['CloudRouterProjectArgs']]]]):
-        pulumi.set(self, "projects", value)
+    @project.setter
+    def project(self, value: Optional[pulumi.Input['CloudRouterProjectArgs']]):
+        pulumi.set(self, "project", value)
 
 
 @pulumi.input_type
@@ -174,7 +174,7 @@ class _CloudRouterState:
                  notifications: Optional[pulumi.Input[Sequence[pulumi.Input['CloudRouterNotificationArgs']]]] = None,
                  order: Optional[pulumi.Input['CloudRouterOrderArgs']] = None,
                  package: Optional[pulumi.Input['CloudRouterPackageArgs']] = None,
-                 projects: Optional[pulumi.Input[Sequence[pulumi.Input['CloudRouterProjectArgs']]]] = None,
+                 project: Optional[pulumi.Input['CloudRouterProjectArgs']] = None,
                  state: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input[str]] = None):
         """
@@ -189,7 +189,7 @@ class _CloudRouterState:
         :param pulumi.Input[Sequence[pulumi.Input['CloudRouterNotificationArgs']]] notifications: Preferences for notifications on Fabric Cloud Router configuration or status changes
         :param pulumi.Input['CloudRouterOrderArgs'] order: Order information related to this Fabric Cloud Router
         :param pulumi.Input['CloudRouterPackageArgs'] package: Fabric Cloud Router package
-        :param pulumi.Input[Sequence[pulumi.Input['CloudRouterProjectArgs']]] projects: Fabric Cloud Router project
+        :param pulumi.Input['CloudRouterProjectArgs'] project: Fabric Cloud Router project
         :param pulumi.Input[str] state: Fabric Cloud Router overall state
         :param pulumi.Input[str] type: Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
         """
@@ -213,8 +213,8 @@ class _CloudRouterState:
             pulumi.set(__self__, "order", order)
         if package is not None:
             pulumi.set(__self__, "package", package)
-        if projects is not None:
-            pulumi.set(__self__, "projects", projects)
+        if project is not None:
+            pulumi.set(__self__, "project", project)
         if state is not None:
             pulumi.set(__self__, "state", state)
         if type is not None:
@@ -342,15 +342,15 @@ class _CloudRouterState:
 
     @property
     @pulumi.getter
-    def projects(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['CloudRouterProjectArgs']]]]:
+    def project(self) -> Optional[pulumi.Input['CloudRouterProjectArgs']]:
         """
         Fabric Cloud Router project
         """
-        return pulumi.get(self, "projects")
+        return pulumi.get(self, "project")
 
-    @projects.setter
-    def projects(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['CloudRouterProjectArgs']]]]):
-        pulumi.set(self, "projects", value)
+    @project.setter
+    def project(self, value: Optional[pulumi.Input['CloudRouterProjectArgs']]):
+        pulumi.set(self, "project", value)
 
     @property
     @pulumi.getter
@@ -389,7 +389,7 @@ class CloudRouter(pulumi.CustomResource):
                  notifications: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterNotificationArgs']]]]] = None,
                  order: Optional[pulumi.Input[pulumi.InputType['CloudRouterOrderArgs']]] = None,
                  package: Optional[pulumi.Input[pulumi.InputType['CloudRouterPackageArgs']]] = None,
-                 projects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']]]]] = None,
+                 project: Optional[pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -431,7 +431,7 @@ class CloudRouter(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterNotificationArgs']]]] notifications: Preferences for notifications on Fabric Cloud Router configuration or status changes
         :param pulumi.Input[pulumi.InputType['CloudRouterOrderArgs']] order: Order information related to this Fabric Cloud Router
         :param pulumi.Input[pulumi.InputType['CloudRouterPackageArgs']] package: Fabric Cloud Router package
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']]]] projects: Fabric Cloud Router project
+        :param pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']] project: Fabric Cloud Router project
         :param pulumi.Input[str] type: Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
         """
         ...
@@ -492,7 +492,7 @@ class CloudRouter(pulumi.CustomResource):
                  notifications: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterNotificationArgs']]]]] = None,
                  order: Optional[pulumi.Input[pulumi.InputType['CloudRouterOrderArgs']]] = None,
                  package: Optional[pulumi.Input[pulumi.InputType['CloudRouterPackageArgs']]] = None,
-                 projects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']]]]] = None,
+                 project: Optional[pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -516,7 +516,7 @@ class CloudRouter(pulumi.CustomResource):
             if package is None and not opts.urn:
                 raise TypeError("Missing required property 'package'")
             __props__.__dict__["package"] = package
-            __props__.__dict__["projects"] = projects
+            __props__.__dict__["project"] = project
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__.__dict__["type"] = type
@@ -544,7 +544,7 @@ class CloudRouter(pulumi.CustomResource):
             notifications: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterNotificationArgs']]]]] = None,
             order: Optional[pulumi.Input[pulumi.InputType['CloudRouterOrderArgs']]] = None,
             package: Optional[pulumi.Input[pulumi.InputType['CloudRouterPackageArgs']]] = None,
-            projects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']]]]] = None,
+            project: Optional[pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']]] = None,
             state: Optional[pulumi.Input[str]] = None,
             type: Optional[pulumi.Input[str]] = None) -> 'CloudRouter':
         """
@@ -564,7 +564,7 @@ class CloudRouter(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterNotificationArgs']]]] notifications: Preferences for notifications on Fabric Cloud Router configuration or status changes
         :param pulumi.Input[pulumi.InputType['CloudRouterOrderArgs']] order: Order information related to this Fabric Cloud Router
         :param pulumi.Input[pulumi.InputType['CloudRouterPackageArgs']] package: Fabric Cloud Router package
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']]]] projects: Fabric Cloud Router project
+        :param pulumi.Input[pulumi.InputType['CloudRouterProjectArgs']] project: Fabric Cloud Router project
         :param pulumi.Input[str] state: Fabric Cloud Router overall state
         :param pulumi.Input[str] type: Notification Type - ALL,CONNECTION*APPROVAL,SALES*REP_NOTIFICATIONS, NOTIFICATIONS
         """
@@ -582,7 +582,7 @@ class CloudRouter(pulumi.CustomResource):
         __props__.__dict__["notifications"] = notifications
         __props__.__dict__["order"] = order
         __props__.__dict__["package"] = package
-        __props__.__dict__["projects"] = projects
+        __props__.__dict__["project"] = project
         __props__.__dict__["state"] = state
         __props__.__dict__["type"] = type
         return CloudRouter(resource_name, opts=opts, __props__=__props__)
@@ -669,11 +669,11 @@ class CloudRouter(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def projects(self) -> pulumi.Output[Optional[Sequence['outputs.CloudRouterProject']]]:
+    def project(self) -> pulumi.Output[Optional['outputs.CloudRouterProject']]:
         """
         Fabric Cloud Router project
         """
-        return pulumi.get(self, "projects")
+        return pulumi.get(self, "project")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
The upstream submodule was initially added using the last commit, but the upgrade-provider pulumi tool needs the SHA of a tag. I have manually checkout upstream to [v1.19.0](https://github.com/equinix/terraform-provider-equinix/releases/tag/v1.19.0) and updated the go dependencies to that version as well

closed https://github.com/equinix/pulumi-equinix/pull/31 in favor of this PR