### PR TITLE
fix: add missing variable in release gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     tags:
       - v*.*.*
 env:
+  PROVIDER: equinix
   DOTNETVERSION: 7.0.x
   GOVERSION: 1.21.x
   JAVAVERSION: "11"


### PR DESCRIPTION
Prev release workflow was failing in https://github.com/equinix/pulumi-equinix/actions/runs/6789447917/job/18456647854