### PR TITLE
chore: renovate should ignore sdk dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "ignorePaths": [
+    "sdk/**",
+    "!sdk/go.mod",
+    "!sdk/go.sum"
   ]
 }


### PR DESCRIPTION
SDKs are autogenerated and should be ignored by renovate