### PR TITLE
fix: patch to remove failing provider meta schema

### DIFF
--- a/patches/0001-pulumi-user-agent.patch
+++ b/patches/0001-pulumi-user-agent.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ocobleseqx <oscar.cobles@eu.equinix.com>
 Date: Wed, 6 Mar 2024 00:55:10 +0100
-Subject: [PATCH 1/2] pulumi user agent
+Subject: [PATCH 1/3] pulumi user agent
 
 Signed-off-by: ocobleseqx <oscar.cobles@eu.equinix.com>
 

--- a/patches/0002-shim-to-expose-internal-provider.patch
+++ b/patches/0002-shim-to-expose-internal-provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ocobleseqx <oscar.cobles@eu.equinix.com>
 Date: Wed, 6 Mar 2024 01:09:42 +0100
-Subject: [PATCH 2/2] shim to expose internal provider
+Subject: [PATCH 2/3] shim to expose internal provider
 
 Signed-off-by: ocobleseqx <oscar.cobles@eu.equinix.com>
 

--- a/patches/0003-remove-provider-meta.patch
+++ b/patches/0003-remove-provider-meta.patch
@@ -1,0 +1,141 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ocobleseqx <oscar.cobles@eu.equinix.com>
+Date: Wed, 6 Mar 2024 19:08:04 +0100
+Subject: [PATCH 3/3] remove provider meta
+
+Signed-off-by: ocobleseqx <oscar.cobles@eu.equinix.com>
+
+diff --git a/equinix/provider.go b/equinix/provider.go
+index b9af613..25aed7b 100644
+--- a/equinix/provider.go
++++ b/equinix/provider.go
+@@ -147,12 +147,6 @@ func Provider() *schema.Provider {
+ 			"equinix_metal_bgp_session":          resourceMetalBGPSession(),
+ 			"equinix_metal_port_vlan_attachment": resourceMetalPortVlanAttachment(),
+ 		},
+-		ProviderMetaSchema: map[string]*schema.Schema{
+-			"module_name": {
+-				Type:     schema.TypeString,
+-				Optional: true,
+-			},
+-		},
+ 	}
+ 
+ 	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+@@ -161,10 +155,6 @@ func Provider() *schema.Provider {
+ 	return provider
+ }
+ 
+-type providerMeta struct {
+-	ModuleName string `cty:"module_name"`
+-}
+-
+ func configureProvider(ctx context.Context, d *schema.ResourceData, p *schema.Provider) (interface{}, diag.Diagnostics) {
+ 	mrws := d.Get("max_retry_wait_seconds").(int)
+ 	rt := d.Get("request_timeout").(int)
+@@ -180,11 +170,7 @@ func configureProvider(ctx context.Context, d *schema.ResourceData, p *schema.Pr
+ 		MaxRetries:     d.Get("max_retries").(int),
+ 		MaxRetryWait:   time.Duration(mrws) * time.Second,
+ 	}
+-	meta := providerMeta{}
+ 
+-	if err := d.GetProviderMeta(&meta); err != nil {
+-		return nil, diag.FromErr(err)
+-	}
+ 	config.TerraformVersion = p.TerraformVersion
+ 	if config.TerraformVersion == "" {
+ 		// Terraform 0.12 introduced this field to the protocol
+diff --git a/internal/config/config.go b/internal/config/config.go
+index 8b93e11..ac55739 100644
+--- a/internal/config/config.go
++++ b/internal/config/config.go
+@@ -38,10 +38,6 @@ const (
+ 	MetalAuthTokenEnvVar = "METAL_AUTH_TOKEN"
+ )
+ 
+-type ProviderMeta struct {
+-	ModuleName string `cty:"module_name"`
+-}
+-
+ type DumpTransport struct {
+ 	r http.RoundTripper
+ }
+@@ -341,16 +337,7 @@ func (c *Config) AddFwModuleToMetalUserAgent(ctx context.Context, meta tfsdk.Con
+ 	c.Metal.UserAgent = generateFwModuleUserAgentString(ctx, meta, c.metalUserAgent)
+ }
+ 
+-func generateFwModuleUserAgentString(ctx context.Context, meta tfsdk.Config, baseUserAgent string) string {
+-	var m ProviderMeta
+-	diags := meta.Get(ctx, &m)
+-	if diags.HasError() {
+-		log.Printf("[WARN] error retrieving provider_meta")
+-		return baseUserAgent
+-	}
+-	if m.ModuleName != "" {
+-		return strings.Join([]string{m.ModuleName, baseUserAgent}, " ")
+-	}
++func generateFwModuleUserAgentString(_ context.Context, _ tfsdk.Config, baseUserAgent string) string {
+ 	return baseUserAgent
+ }
+ 
+@@ -358,17 +345,7 @@ func (c *Config) AddModuleToMetalUserAgent(d *schema.ResourceData) {
+ 	c.Metal.UserAgent = generateModuleUserAgentString(d, c.metalUserAgent)
+ }
+ 
+-func generateModuleUserAgentString(d *schema.ResourceData, baseUserAgent string) string {
+-	var m ProviderMeta
+-	err := d.GetProviderMeta(&m)
+-	if err != nil {
+-		log.Printf("[WARN] error retrieving provider_meta")
+-		return baseUserAgent
+-	}
+-
+-	if m.ModuleName != "" {
+-		return strings.Join([]string{m.ModuleName, baseUserAgent}, " ")
+-	}
++func generateModuleUserAgentString(_ *schema.ResourceData, baseUserAgent string) string {
+ 	return baseUserAgent
+ }
+ 
+diff --git a/internal/provider/provider.go b/internal/provider/provider.go
+index b6a6246..fb6bc50 100644
+--- a/internal/provider/provider.go
++++ b/internal/provider/provider.go
+@@ -14,7 +14,6 @@ import (
+ 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+ 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+ 	"github.com/hashicorp/terraform-plugin-framework/provider"
+-	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
+ 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+ 	"github.com/hashicorp/terraform-plugin-framework/resource"
+ 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+@@ -27,7 +26,7 @@ type FrameworkProvider struct {
+ 	Meta            *config.Config
+ }
+ 
+-func CreateFrameworkProvider(version string) provider.ProviderWithMetaSchema {
++func CreateFrameworkProvider(version string) provider.Provider {
+ 	return &FrameworkProvider{
+ 		ProviderVersion: version,
+ 	}
+@@ -97,20 +96,6 @@ func (p *FrameworkProvider) Schema(
+ 	}
+ }
+ 
+-func (p *FrameworkProvider) MetaSchema(
+-	ctx context.Context,
+-	req provider.MetaSchemaRequest,
+-	resp *provider.MetaSchemaResponse,
+-) {
+-	resp.Schema = metaschema.Schema{
+-		Attributes: map[string]metaschema.Attribute{
+-			"module_name": schema.StringAttribute{
+-				Optional: true,
+-			},
+-		},
+-	}
+-}
+-
+ func (p *FrameworkProvider) Resources(ctx context.Context) []func() resource.Resource {
+ 	return []func() resource.Resource{
+ 		metalgateway.NewResource,


### PR DESCRIPTION
Provider was constantly failing in sdk v2 resources with the error in screenshot below. It fails in https://github.com/pulumi/pulumi-terraform-bridge/blob/f6013b69e741bc73632fd42ba2b4630a1f2cc3ff/pkg/tfshim/sdk-v2/provider2.go#L290 and seems to me an error in the terraform bridge plugin. I can't find any explanation why it takes the value of Config instead of Meta. 'm going to open an issue in the bridge plugin but for now I have added this patch to remove the ProviderMetaSchema from the upstream terraform provider, which in fact has no use here in pulumi.

![image](https://github.com/equinix/pulumi-equinix/assets/68897552/eb113680-440f-4252-83f2-19051d0a6ad6)
