### PR TITLE
fix: Adding project_id block to fabric-cloud-router examples

### DIFF
--- a/docs/resource/equinix_fabric_cloud_router.examples.md
+++ b/docs/resource/equinix_fabric_cloud_router.examples.md
@@ -24,6 +24,9 @@ const router = new equinix.fabric.CloudRouter("router", {
     account: {
         accountNumber: 272010,
     },
+    "project": {
+        "projectId": "995072000433550"
+    }
 });
 export const routerId = router.id;
 ```
@@ -51,6 +54,9 @@ router = equinix.fabric.CloudRouter("router",
     )],
     account=equinix.fabric.CloudRouterAccountArgs(
         account_number=272010,
+    ))
+    project=equinix.fabric.CloudRouterProjectArgs(
+        project_id=995072000433550,
     ))
 pulumi.export("routerId", router.id)
 ```
@@ -91,6 +97,9 @@ func main() {
 			Account: &fabric.CloudRouterAccountArgs{
 				AccountNumber: pulumi.Int(272010),
 			},
+			Project: &fabric.CloudRouterProjectArgs{
+				ProjectId: pulumi.String("995072000433550"),
+            },
 		})
 		if err != nil {
 			return err
@@ -137,6 +146,10 @@ return await Deployment.RunAsync(() =>
         Account = new Equinix.Fabric.Inputs.CloudRouterAccountArgs
         {
             AccountNumber = 272010,
+        },
+        Project = new Equinix.Fabric.Inputs.CloudRouterProjectArgs
+        {
+            ProjectId = "995072000433550",
         },
     });
 
@@ -190,6 +203,9 @@ public class App {
             .account(CloudRouterAccountArgs.builder()
                 .accountNumber(272010)
                 .build())
+            .project(CloudRouterProjectArgs.builder()
+                .projectId("995072000433550")
+                .build())
             .build());
 
         ctx.export("routerId", router.id());
@@ -219,6 +235,8 @@ resources:
         - example@equinix.com
       account:
         accountNumber: 272010
+      project:
+        projectId: 995072000433550
 outputs:
   routerId: ${router.id}
 ```


### PR DESCRIPTION
Added project_id block to Fabric Cloud Router Example because project_id is required parameter.

Refrence: https://app.swaggerhub.com/apis/equinix-api/fabric/4.13#/Cloud%20Routers/createCloudRouter