### PR TITLE
update goreleaser config file and lock to version 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           args: -p 3 release --clean --timeout 150m0s
-          version: latest
+          version: '~> v2'
     strategy:
       fail-fast: true
   publish_sdk:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,7 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+version: 2
+
 archives:
   - id: archive
     name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}'
@@ -28,7 +32,7 @@ builds:
       - -X github.com/equinix/terraform-provider-equinix/version.ProviderVersion|={{.Tag}}
     main: ./cmd/pulumi-resource-equinix/
 changelog:
-  skip: true
+  disable: true
 release:
   disable: false
   prerelease: auto


### PR DESCRIPTION
Necessary changes to the goreleaser configuration file were not included in the previous PR #99 making it fail in https://github.com/equinix/pulumi-equinix/actions/runs/9659514911/job/26643074014

- version must be specified: `version: 2`
- `changelog.skip` replaced with `changelog.disable`
- Since version must be specified I have locked the version in the gh action to `~> v2`