### PR TITLE
chore(ci): override upgrade-provider action

### DIFF
--- a/.github/actions/upgrade-provider/action.yml
+++ b/.github/actions/upgrade-provider/action.yml
@@ -1,0 +1,117 @@
+name: 'Upgrade provider'
+description: 'An action to upgrade bridged providers'
+inputs:
+  kind:
+    description: The kind of upgrade to perform; valid options are ["all", "provider", "bridge"]
+    required: true
+    default: "all"
+  username:
+    description: 'The username for git configuration'
+    required: false
+    default: ${{ github.actor }}
+  email:
+    description: 'The email for git configuration'
+    required: false
+  automerge:
+    description: 'If the created PR should be auto-merged'
+    required: false
+    default: false
+  pr-assign:
+    description: |
+      A user to assign the upgrade PR to
+    required: true
+    default: ${{ github.actor }}
+  pr-reviewers:
+    description: |
+      Handles of reviewers to assign the created PRs to. If empty, default reviewers are assigned.
+    required: false
+    default: ""
+  pr-description:
+    description: |
+      Extra description to insert in the auto-generated pull request.
+    required: false
+    default: ""
+  pr-title-prefix:
+    description: |
+      Prefix to add to the title of the auto-generated pull request.
+    required: false
+    default: ""
+  target-bridge-version:
+    description: |
+      Informs which version of pulumi-terraform-bridge to target for updating the bridge; valid
+      options are "latest", a version like "1.2.3", or a Git commit hash reference like "cad926a2d".
+    required: false
+    default: "latest"
+  target-pulumi-version:
+    description: |
+      Set the version of `pulumi/pkg` and `pulumi/sdk` to depend on for bridged providers. Currently,
+      these versions inform the linked runtime and SDK generation in all languages except Java. Valid
+      options are:
+      - "", "follow": Use the same version as pulumi-terraform-bridge
+      - A go version such as "v3.90.1"
+      - A commit SHA in pulumi/pulumi such as "ac71ebc1d34e5ccfd1a7fed61e6ff43a3160f3cb"
+    required: false
+    default: ""
+  target-java-version:
+    description: |
+      Explicitly set the version pf pulumi/pulumi-java to generate the java sdk with.
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+  - name: Install Go
+    uses: actions/setup-go@v3
+    with:
+      go-version: 1.21.x
+  - name: Install pulumictl
+    uses: jaxxstorm/action-install-gh-release@v1.10.0
+    with:
+      repo: pulumi/pulumictl
+  - name: Install Pulumi CLI
+    uses: pulumi/actions@v4
+  - name: Checkout repo
+    uses: actions/checkout@v3
+    with:
+      ref: ${{ github.ref_name }}
+  - name: Unshallow clone for tags
+    run: git fetch --prune --unshallow --tags
+    shell: bash
+  - name: Install upgrade-provider
+    run: go install github.com/pulumi/upgrade-provider@main
+    shell: bash
+  - name: Setup Gradle
+    uses: gradle/gradle-build-action@v2
+    with:
+      gradle-version: "7.6"
+  - name: "Set up git identity: name"
+    run: git config --global user.name '${{ inputs.username }}'
+    shell: bash
+  - name: "Set up git identity: email"
+    if: ${{ inputs.email != '' }}
+    run: git config --global user.email '${{ inputs.email }}'
+    shell: bash
+  - name: Run upgrade-provider
+    run: |
+      upgrade-provider "$REPO" --kind="$KIND" ${TBV:+--target-bridge-version="$TBV"} ${ASS:+--pr-assign="$ASS"} ${REV:+--pr-reviewers="$REV"} ${DESC:+--pr-description="$DESC"} ${PREF:+--pr-title-prefix="$PREF"} ${PUV:+--target-pulumi-version="$PUV"} ${JV:+--java-version="$JV"}
+    shell: bash
+    env:
+      GH_TOKEN: ${{ env.GH_TOKEN }}
+      REPO: ${{ github.repository }}
+      KIND: ${{ inputs.kind }}
+      TBV: ${{ inputs.target-bridge-version }}
+      ASS: ${{ inputs.pr-assign }}
+      REV: ${{ inputs.pr-reviewers }}
+      DESC: ${{ inputs.pr-description }}
+      PREF: ${{ inputs.pr-title-prefix }}
+      PUV: ${{ inputs.target-pulumi-version }}
+      JV: ${{ inputs.target-java-version }}
+  - name: Set PR to auto-merge
+    if: ${{ inputs.automerge == 'true' }}
+    # This tolerates repos that do not have auto-merge enabled.  `continue-on-error: true`
+    # should be removed when https://github.com/pulumi/home/issues/3140 closes.
+    continue-on-error: true
+    run: gh pr merge --auto --squash --delete-branch
+    shell: bash
+    env:
+      GH_TOKEN: ${{ env.GH_TOKEN }}

--- a/.github/actions/upgrade-provider/action.yml
+++ b/.github/actions/upgrade-provider/action.yml
@@ -17,10 +17,9 @@ inputs:
     required: false
     default: false
   pr-assign:
-    description: |
-      A user to assign the upgrade PR to
-    required: true
-    default: ${{ github.actor }}
+    description: 'A user to assign the upgrade PR to'
+    required: false
+    default: ""
   pr-reviewers:
     description: |
       Handles of reviewers to assign the created PRs to. If empty, default reviewers are assigned.

--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -65,6 +65,7 @@ jobs:
         target-bridge-version: ${{ inputs.target-bridge-version }}
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+        pr-assign: ${{ github.actor }}
     # TODO(ocobles) Set back when pr-assign is available or we have an Equinix bot token
     # - name: Call upgrade provider action
     #   if: github.event_name == 'repository_dispatch'

--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -48,38 +48,32 @@ jobs:
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action
-      if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      # TODO(ocobles): upgrade-provider tool tries to assign the PR to the user who created it.
+      # Since we don't have an Equinix bot user, we are using the GITHUB_TOKEN. This results in an
+      # error when trying to assign the PR to the user of the token (github-action). As a workaround
+      # we override the assign user. The pulumi-upgrade-provider-action does not have this option so
+      # we temporarily overwrite the action locally with a pr-assign input.
+      # Set pulumi-upgrade-provider-action back when pr-assign is available or we have a an Equinix bot token
+      #
+      # uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: ./.github/actions/upgrade-provider
       with:
         kind: bridge
         email: noreply@github.com
         username: GitHub
-        automerge: ${{ github.event.client_payload.automerge }}
-        target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
-        pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
-        pr-description: ${{ github.event.client_payload.pr-description }}
-    ## TODO
-    # - env:
-    #     SLACK_CHANNEL: provider-upgrade-publish-status
-    #     SLACK_COLOR: "#7CFC00"
-    #     SLACK_ICON_EMOJI: ":taco:"
-    #     SLACK_MESSAGE: >-
-    #       Upgrade succeeded :heart_decoration:
-
-    #       PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-    #     SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-    #     SLACK_USERNAME: provider-bot
-    #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-    #   name: Send Upgrade Success To Slack
-    #   uses: rtCamp/action-slack-notify@v2
-    # - env:
-    #     SLACK_CHANNEL: provider-upgrade-publish-status
-    #     SLACK_COLOR: "#FF0000"
-    #     SLACK_ICON_EMOJI: ":taco:"
-    #     SLACK_MESSAGE: " Upgrade failed :x:"
-    #     SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-    #     SLACK_USERNAME: provider-bot
-    #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-    #   if: failure()
-    #   name: Send Upgrade Failure To Slack
-    #   uses: rtCamp/action-slack-notify@v2
+        automerge: ${{ inputs.automerge }}
+        target-bridge-version: ${{ inputs.target-bridge-version }}
+        pr-reviewers: ${{ inputs.pr-reviewers }}
+        pr-description: ${{ inputs.pr-description }}
+    # TODO(ocobles) Set back when pr-assign is available or we have an Equinix bot token
+    # - name: Call upgrade provider action
+    #   if: github.event_name == 'repository_dispatch'
+    #   uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+    #   with:
+    #     kind: bridge
+    #     email: noreply@github.com
+    #     username: GitHub
+    #     automerge: ${{ github.event.client_payload.automerge }}
+    #     target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
+    #     pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
+    #     pr-description: ${{ github.event.client_payload.pr-description }}

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -10,12 +10,21 @@ on:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DEFAULT_PR_ASSIGN: ocobles
 jobs:
   upgrade_provider:
     if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
+    - name: Set pr-assign variable
+      id: set-pr-assign
+      run: |
+        if [ "${{ github.actor }}" == "github-actions[bot]" ]; then
+          echo "PR_ASSIGN=${{ env.DEFAULT_PR_ASSIGN }}" >> $GITHUB_ENV
+        else
+          echo "PR_ASSIGN=${{ github.actor }}" >> $GITHUB_ENV
+        fi
     - name: Call upgrade provider action
       # TODO(ocobles): upgrade-provider tool tries to assign the PR to the user who created it.
       # Since we don't have an Equinix bot user, we are using the GITHUB_TOKEN. This results in an
@@ -30,3 +39,4 @@ jobs:
         kind: all
         email: noreply@github.com
         username: GitHub
+        pr-assign: ${{ env.PR_ASSIGN }}

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -17,33 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      # TODO(ocobles): upgrade-provider tool tries to assign the PR to the user who created it.
+      # Since we don't have an Equinix bot user, we are using the GITHUB_TOKEN. This results in an
+      # error when trying to assign the PR to the user of the token (github-action). As a workaround
+      # we override the assign user. The pulumi-upgrade-provider-action does not have this option so
+      # we temporarily overwrite the action locally with a pr-assign input.
+      # Set pulumi-upgrade-provider-action back when pr-assign is available or we have a bot token
+      #
+      # uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: ./.github/actions/upgrade-provider
       with:
         kind: all
         email: noreply@github.com
         username: GitHub
-    ## TODO
-    # - env:
-    #     SLACK_CHANNEL: provider-upgrade-publish-status
-    #     SLACK_COLOR: "#7CFC00"
-    #     SLACK_ICON_EMOJI: ":taco:"
-    #     SLACK_MESSAGE: >-
-    #       Upgrade succeeded :heart_decoration:
-
-    #       PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-    #     SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-    #     SLACK_USERNAME: provider-bot
-    #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-    #   name: Send Upgrade Success To Slack
-    #   uses: rtCamp/action-slack-notify@v2
-    # - env:
-    #     SLACK_CHANNEL: provider-upgrade-publish-status
-    #     SLACK_COLOR: "#FF0000"
-    #     SLACK_ICON_EMOJI: ":taco:"
-    #     SLACK_MESSAGE: " Upgrade failed :x:"
-    #     SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-    #     SLACK_USERNAME: provider-bot
-    #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-    #   if: failure()
-    #   name: Send Upgrade Failure To Slack
-    #   uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
upgrade-provider tool tries to assign the PR to the user who created it. Since we don't have an Equinix bot user, we are using the GITHUB_TOKEN. This results in an error when trying to assign the PR to the user of the token (github-action). As a workaround we override the assign user. The pulumi-upgrade-provider-action does not have this option so we temporarily overwrite the action locally with a pr-assign input that takes `github.actor` by default.

ERROR: GraphQL: Could not resolve to a User with the login of 'github-actions[bot]'. (u000)
https://github.com/equinix/pulumi-equinix/actions/runs/9976483769/job/27568775953