### PR TITLE
chore(ci): add feature prefix to automated upgrade PRs

### DIFF
--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -42,7 +42,7 @@ jobs:
         ref: ${{ github.ref_name }}
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: bridge
         email: noreply@github.com
@@ -51,6 +51,7 @@ jobs:
         target-bridge-version: ${{ inputs.target-bridge-version }}
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+        pr-title-prefix: "feat: "
     - name: Call upgrade provider action
       # TODO(ocobles): upgrade-provider tool tries to assign the PR to the user who created it.
       # Since we don't have an Equinix bot user, we are using the GITHUB_TOKEN. This results in an
@@ -70,6 +71,7 @@ jobs:
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
         pr-assign: ${{ github.actor }}
+        pr-title-prefix: "feat: "
     # TODO(ocobles) Set back when pr-assign is available or we have an Equinix bot token
     # - name: Call upgrade provider action
     #   if: github.event_name == 'repository_dispatch'

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -44,3 +44,4 @@ jobs:
         email: noreply@github.com
         username: GitHub
         pr-assign: ${{ env.PR_ASSIGN }}
+        pr-title-prefix: "feat: "


### PR DESCRIPTION
This adds the `pr-title-prefix` argument to the upgrade steps in the upgrade-bridge and upgrade-provider workflows.  In the case where we were using the official Pulumi upgrade action, this upgrades that action to the latest version, v0.0.12.  That version introduced the `pr-title-prefix` argument and matches the base code of our custom action.

Part of #114 