### PR TITLE
chore(ci): create release with semantic-release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: release
 on:
-  push:
-    tags:
-      - v*.*.*
+  workflow_dispatch:
+
 env:
   PROVIDER: equinix
   DOTNETVERSION: 7.0.x
@@ -74,6 +73,15 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin/provider.tar.gz
           retention-days: 30
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v3
+        with:
+          semantic_version: 19.0.5
+          extra_plugins: |
+            @semantic-release/git@10.0.0
+            conventional-changelog-conventionalcommits@4.6.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set PreRelease Version
         run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
       - name: Run GoReleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ version: 2
 
 archives:
   - id: archive
-    name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}'
+    name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 before:
   hooks:
     - make tfgen
@@ -23,8 +23,8 @@ builds:
       - linux
     hooks:
       post:
-      - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-      - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
+        - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
+        - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
     ignore: []
     ldflags:
       # The line below MUST align with the module in current provider/go.mod
@@ -34,7 +34,6 @@ builds:
 changelog:
   disable: true
 release:
-  disable: false
-  prerelease: auto
+  mode: keep-existing
 snapshot:
-  name_template: '{{ .Tag }}-SNAPSHOT'
+  name_template: "{{ .Tag }}-SNAPSHOT"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,28 @@
+{
+  "branches": [
+    "main"
+  ],
+  "ci": false,
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+        "labels": false,
+        "releasedLabels": false
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
This converts the release workflow to a push-button workflow.  Instead of pushing a new tag to create a new Pulumi provider release, this updated workflow determines the next version number by analyzing the Conventional Commits tags on all commits made to `main` since the last release.  The GitHub release notes are generated from the commit log.  The GoReleaser config is updated so that GoReleaser will attach binaries to the GitHub release that was created by semantic-release-action instead of expecting to create the release itself.