### PR TITLE
chore(ci): remove submodules init from actions/checkout

### DIFF
--- a/.github/workflows/check-upstream-upgrade.yml
+++ b/.github/workflows/check-upstream-upgrade.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-      with:
-        submodules: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:


### PR DESCRIPTION
workflow `check-upstream-upgrade` is consistently failing with error:

```
fatal: remote error: upload-pack: not our ref 0028d0d7d396775e3c57b122bf1ca8f9e5b020e3
Errors during submodule fetch:
	upstream
```

I'm not sure what the problem is but seems to be a conflict between the steps in the command `upgrade-provider` and the version that action/checkout gets. The `upgrade-provider` command runs `git submodule update --force --init` so we can continue using action/checkout without submodules