### PR TITLE
chore(ci): use default PR assignee for scheduled workflows

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set pr-assign variable
       id: set-pr-assign
       run: |
-        if [ "${{ github.actor }}" == "github-actions[bot]" ]; then
+        if [ "${{ github.event_name }}" == "schedule" ] || ["${{ github.actor }}" == "github-actions[bot]" ]; then
           echo "PR_ASSIGN=${{ env.DEFAULT_PR_ASSIGN }}" >> $GITHUB_ENV
         else
           echo "PR_ASSIGN=${{ github.actor }}" >> $GITHUB_ENV

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -43,7 +43,7 @@ jobs:
       # uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
       uses: ./.github/actions/upgrade-provider
       with:
-        kind: all
+        kind: provider
         email: noreply@github.com
         username: GitHub
         pr-assign: ${{ env.PR_ASSIGN }}

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -24,6 +24,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.ref_name }}
+    - name: Capture current pulumi-java version
+      id: pulumi-java
+      run: |
+        echo "version=$(cat .pulumi-java-gen.version)" >> "$GITHUB_OUTPUT"
     - name: Set pr-assign variable
       id: set-pr-assign
       run: |
@@ -48,3 +52,4 @@ jobs:
         username: GitHub
         pr-assign: ${{ env.PR_ASSIGN }}
         pr-title-prefix: "feat: "
+        target-java-version: ${{ steps.pulumi-java.outputs.version }}


### PR DESCRIPTION
It turns out that scheduled GitHub Actions workflows do not run with the `github-actions[bot]` actor.  Instead the actor in those jobs appears to be whoever last did a `git push` affecting the scheduled workflow file:
https://github.com/orgs/community/discussions/25067#discussioncomment-7178233

This updates the upgrade-provider workflow so that, if the workflow was triggered by a `schedule` event, the workflow will use the default assignee.