### PR TITLE
chore: use only_tfgen instead of tfgen in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ archives:
     name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 before:
   hooks:
-    - make tfgen
+    - make only_tfgen
 builds:
   - binary: pulumi-resource-equinix
     dir: provider


### PR DESCRIPTION
The `make tfgen` target currently generate examples and that step is not necessary at all here since we only want to generate the provider