### PR TITLE
chore(ci): do not run upgrade-provider on new issues

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -3,9 +3,6 @@
 
 name: Upgrade provider
 on:
-  issues:
-    types:
-    - opened
   workflow_dispatch: {}
   schedule:
   # Run every 8 hours Monday through Friday

--- a/out.txt
+++ b/out.txt
@@ -1,7 +1,0 @@
-I0613 12:23:04.230342    8504 api.go:314] Making Pulumi API call: https://api.pulumi.com/api/user
-W0613 12:23:04.257065    8504 pulumi.go:499] A new version of Pulumi is available. To upgrade from version '3.113.0' to '3.120.0', run 
-   $ brew update && brew upgrade pulumi
-or visit https://pulumi.com/docs/install/ for manual instructions and release notes.
-I0613 12:23:04.699092    8504 api.go:328] Pulumi API call response code (https://api.pulumi.com/api/user): 200 OK
-I0613 12:23:04.704407    8504 sink.go:178] defaultSink::Error([38;5;1merror: [0m[0mno Pulumi.yaml project file found (searching upwards from /Users/srpatel/work/pulumi-equinix). If you have not created a project yet, use `pulumi new` to do so: no project file found[0m)
-[38;5;1merror: [0m[0mno Pulumi.yaml project file found (searching upwards from /Users/srpatel/work/pulumi-equinix). If you have not created a project yet, use `pulumi new` to do so: no project file found[0m


### PR DESCRIPTION
The upgrade-provider workflow runs on schedule, and a previous issue is no longer used to run it.
Removing also a log file added by mistake in previous commits