### PR TITLE
chore(ci): switch to bot token for some GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-upstream-upgrade.yml
+++ b/.github/workflows/check-upstream-upgrade.yml
@@ -2,7 +2,7 @@
 # but it is currently not in sync. Any update must be done manually
 
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.EQUINIX_BOT_TOKEN }}
 jobs:
   check_upgrade_provider:
     name: Check for upstream provider upgrades
@@ -33,3 +33,6 @@ jobs:
 name: Check upstream upgrade
 on:
   workflow_dispatch: {} #so we can run this manually if necessary
+  schedule:
+    # Run every 8 hours Monday through Friday
+    - cron: '0 */8 * * 1-5'

--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -29,7 +29,7 @@ on:
         type: boolean
         default: false
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.EQUINIX_BOT_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
@@ -53,34 +53,13 @@ jobs:
         pr-description: ${{ inputs.pr-description }}
         pr-title-prefix: "feat: "
     - name: Call upgrade provider action
-      # TODO(ocobles): upgrade-provider tool tries to assign the PR to the user who created it.
-      # Since we don't have an Equinix bot user, we are using the GITHUB_TOKEN. This results in an
-      # error when trying to assign the PR to the user of the token (github-action). As a workaround
-      # we override the assign user. The pulumi-upgrade-provider-action does not have this option so
-      # we temporarily overwrite the action locally with a pr-assign input.
-      # Set pulumi-upgrade-provider-action back when pr-assign is available or we have a an Equinix bot token
-      #
-      # uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
-      uses: ./.github/actions/upgrade-provider
+      if: github.event_name == 'repository_dispatch'
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: bridge
         email: noreply@github.com
         username: GitHub
-        automerge: ${{ inputs.automerge }}
-        target-bridge-version: ${{ inputs.target-bridge-version }}
-        pr-reviewers: ${{ inputs.pr-reviewers }}
-        pr-description: ${{ inputs.pr-description }}
-        pr-assign: ${{ github.actor }}
-        pr-title-prefix: "feat: "
-    # TODO(ocobles) Set back when pr-assign is available or we have an Equinix bot token
-    # - name: Call upgrade provider action
-    #   if: github.event_name == 'repository_dispatch'
-    #   uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
-    #   with:
-    #     kind: bridge
-    #     email: noreply@github.com
-    #     username: GitHub
-    #     automerge: ${{ github.event.client_payload.automerge }}
-    #     target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
-    #     pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
-    #     pr-description: ${{ github.event.client_payload.pr-description }}
+        automerge: ${{ github.event.client_payload.automerge }}
+        target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
+        pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
+        pr-description: ${{ github.event.client_payload.pr-description }}

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -7,14 +7,10 @@ on:
     types:
     - opened
   workflow_dispatch: {}
-  schedule:
-  # Run every 8 hours Monday through Friday
-  - cron: '0 */8 * * 1-5'
 
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.EQUINIX_BOT_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  DEFAULT_PR_ASSIGN: ocobles
 jobs:
   upgrade_provider:
     name: upgrade-provider
@@ -28,28 +24,11 @@ jobs:
       id: pulumi-java
       run: |
         echo "version=$(cat .pulumi-java-gen.version)" >> "$GITHUB_OUTPUT"
-    - name: Set pr-assign variable
-      id: set-pr-assign
-      run: |
-        if [ "${{ github.event_name }}" == "schedule" ] || ["${{ github.actor }}" == "github-actions[bot]" ]; then
-          echo "PR_ASSIGN=${{ env.DEFAULT_PR_ASSIGN }}" >> $GITHUB_ENV
-        else
-          echo "PR_ASSIGN=${{ github.actor }}" >> $GITHUB_ENV
-        fi
     - name: Call upgrade provider action
-      # TODO(ocobles): upgrade-provider tool tries to assign the PR to the user who created it.
-      # Since we don't have an Equinix bot user, we are using the GITHUB_TOKEN. This results in an
-      # error when trying to assign the PR to the user of the token (github-action). As a workaround
-      # we override the assign user. The pulumi-upgrade-provider-action does not have this option so
-      # we temporarily overwrite the action locally with a pr-assign input.
-      # Set pulumi-upgrade-provider-action back when pr-assign is available or we have a bot token
-      #
-      # uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
-      uses: ./.github/actions/upgrade-provider
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: provider
         email: noreply@github.com
         username: GitHub
-        pr-assign: ${{ env.PR_ASSIGN }}
         pr-title-prefix: "feat: "
         target-java-version: ${{ steps.pulumi-java.outputs.version }}


### PR DESCRIPTION
GitHub events generated by the built-in, automatic GitHub Actions token are explicitly ignored by GitHub Actions.  This means that if an issue or pull request is created with the built-in token, that issue or pull request will not trigger other GitHub Actions workflows.

We previously worked around this issue by switching to scheduled workflows where necessary, but this leads to a large number of duplicate pull requests.  Using a custom bot token for the `upgrade-provider` command allows us to roll back the move to scheduled jobs and rely on GitHub events to trigger the necessary workflows on-demand.