### PR TITLE
chore: use `latest` version of the provider for go.mod in examples

### DIFF
--- a/examples/metal/ssh_key/csharp/equinix-metal-ssh_key.csproj
+++ b/examples/metal/ssh_key/csharp/equinix-metal-ssh_key.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/ssh_key/csharp/equinix-metal-ssh_key.csproj
+++ b/examples/metal/ssh_key/csharp/equinix-metal-ssh_key.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
 		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
+		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/file/csharp/equinix-network-file.csproj
+++ b/examples/network/file/csharp/equinix-network-file.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/file/csharp/equinix-network-file.csproj
+++ b/examples/network/file/csharp/equinix-network-file.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
 		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
+		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
 	</ItemGroup>
 
 </Project>

--- a/scripts/generate_examples.sh
+++ b/scripts/generate_examples.sh
@@ -22,13 +22,22 @@ OUTPUT_DIR="${SCRIPT_DIR}/../docs/resource"
 # Pulumi Equinix plugin version installed
 VERSION=$(.pulumi/bin/pulumictl get version --language generic)
 
-get_patch() {
+# Note: The go examples require a specific version in go.mod. This simply makes up the new version,
+# although sometimes the new version will just be a fix and the version specified the examples
+# will be higher than the latest available tag
+increment_minor_version() {
     local version="$1"
-    local new_version=$(echo "$version" | awk -F'[.-]' '{print $1"."$2"."$3}')
+    local cleaned_version=$(echo "$version" | sed 's/[-+].*//')
+    local major=$(echo "$cleaned_version" | awk -F'.' '{print $1}')
+    local minor=$(echo "$cleaned_version" | awk -F'.' '{print $2}')
+    local new_minor=$((minor + 1))
+    # build next minor version
+    local new_version="${major}.${new_minor}.0"
+
     echo "$new_version"
 }
 
-GOLANG_MIN_NEXT_VERSION=$(get_patch "$VERSION")
+GOLANG_NEXT_MINOR_VERSION=$(increment_minor_version "$VERSION")
 
 # Find all Pulumi.yaml files within the examples directory structure
 EXISTING_PULUMI_EXAMPLES=()
@@ -244,7 +253,7 @@ generate_examples_and_docs() {
         sed -i.bak "s|$VERSION|<1.0.0|g" $PULUMI_DIR/typescript/package.json
         rm "$PULUMI_DIR"/typescript/package.json.bak
         ## go
-        sed -i.bak "s|github.com/equinix/pulumi-equinix/sdk [^ ]*|github.com/equinix/pulumi-equinix/sdk $GOLANG_MIN_NEXT_VERSION|g" "$PULUMI_DIR/go/go.mod"
+        sed -i.bak "s|github.com/equinix/pulumi-equinix/sdk [^ ]*|github.com/equinix/pulumi-equinix/sdk $GOLANG_NEXT_MINOR_VERSION|g" "$PULUMI_DIR/go/go.mod"
         rm "$PULUMI_DIR"/go/go.sum "$PULUMI_DIR"/go/go.mod.bak
 
         # Read each source file

--- a/scripts/generate_examples.sh
+++ b/scripts/generate_examples.sh
@@ -21,23 +21,8 @@ EXAMPLES_DIR="${SCRIPT_DIR}/../examples/"
 OUTPUT_DIR="${SCRIPT_DIR}/../docs/resource"
 # Pulumi Equinix plugin version installed
 VERSION=$(.pulumi/bin/pulumictl get version --language generic)
-
-# Note: The go examples require a specific version in go.mod. This simply makes up the new version,
-# although sometimes the new version will just be a fix and the version specified the examples
-# will be higher than the latest available tag
-increment_minor_version() {
-    local version="$1"
-    local cleaned_version=$(echo "$version" | sed 's/[-+].*//')
-    local major=$(echo "$cleaned_version" | awk -F'.' '{print $1}')
-    local minor=$(echo "$cleaned_version" | awk -F'.' '{print $2}')
-    local new_minor=$((minor + 1))
-    # build next minor version
-    local new_version="${major}.${new_minor}.0"
-
-    echo "$new_version"
-}
-
-GOLANG_NEXT_MINOR_VERSION=$(increment_minor_version "$VERSION")
+# Pulumi Equinix plugin version specified in the examples go.mod files
+GOLANG_VERSION="latest"
 
 # Find all Pulumi.yaml files within the examples directory structure
 EXISTING_PULUMI_EXAMPLES=()
@@ -253,7 +238,7 @@ generate_examples_and_docs() {
         sed -i.bak "s|$VERSION|<1.0.0|g" $PULUMI_DIR/typescript/package.json
         rm "$PULUMI_DIR"/typescript/package.json.bak
         ## go
-        sed -i.bak "s|github.com/equinix/pulumi-equinix/sdk [^ ]*|github.com/equinix/pulumi-equinix/sdk $GOLANG_NEXT_MINOR_VERSION|g" "$PULUMI_DIR/go/go.mod"
+        sed -i.bak "s|github.com/equinix/pulumi-equinix/sdk [^ ]*|github.com/equinix/pulumi-equinix/sdk $GOLANG_VERSION|g" "$PULUMI_DIR/go/go.mod"
         rm "$PULUMI_DIR"/go/go.sum "$PULUMI_DIR"/go/go.mod.bak
 
         # Read each source file


### PR DESCRIPTION
The go examples require a specific version in go.mod. 
~This simply makes up the new version, although sometimes the new version will just be a fix and the version specified in the go examples will be higher than the latest available tag~
This adds label `latest` in go.mod pulumi-equinix/sdk import

```
require (
	github.com/equinix/pulumi-equinix/sdk latest
	github.com/pulumi/pulumi/sdk/v3 v3.128.0
)
```