### PR TITLE
feat: Upgrade terraform-provider-equinix to v2.4.0

### DIFF
--- a/examples/fabric/cloud_router/go/go.mod
+++ b/examples/fabric/cloud_router/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-cloud_router
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_fcr_to_azure/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_azure/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_fcr_to_azure
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_fcr_to_metal/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_metal/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_fcr_to_metal
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_fcr_to_network/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_network/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_fcr_to_network
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_fcr_to_port/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_port/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_fcr_to_port
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_metal_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_metal_to_aws/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_metal_to_aws
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_port_to_aws/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_port_to_aws
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_network_eplan/go/go.mod
+++ b/examples/fabric/connection/example_port_to_network_eplan/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_port_to_network_eplan
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_network_evplan/go/go.mod
+++ b/examples/fabric/connection/example_port_to_network_evplan/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_port_to_network_evplan
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_port/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_port_to_port
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_port_access_epl/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port_access_epl/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_port_to_port_access_epl
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_port_epl/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port_epl/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_port_to_port_epl
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_vd/go/go.mod
+++ b/examples/fabric/connection/example_port_to_vd/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_port_to_vd
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_token_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_token_to_aws/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_token_to_aws
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_vd_to_azure/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_azure/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_vd_to_azure
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_vd_to_azure_redundant/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_azure_redundant/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_vd_to_azure_redundant
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_vd_to_network/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_network/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_vd_to_network
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_vd_to_token/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_token/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-connection-example_vd_to_token
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/network/go/go.mod
+++ b/examples/fabric/network/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-network
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/routing_protocol/example_1/go/go.mod
+++ b/examples/fabric/routing_protocol/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-routing_protocol-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/routing_protocol/example_2/go/go.mod
+++ b/examples/fabric/routing_protocol/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-routing_protocol-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/routing_protocol/example_3/go/go.mod
+++ b/examples/fabric/routing_protocol/example_3/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-routing_protocol-example_3
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/service_profile/go/go.mod
+++ b/examples/fabric/service_profile/go/go.mod
@@ -2,10 +2,10 @@ module equinix-fabric-service_profile
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/bgp_session/go/go.mod
+++ b/examples/metal/bgp_session/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-bgp_session
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi-null/sdk v0.0.5
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/metal/connection/example_fabric_billed/go/go.mod
+++ b/examples/metal/connection/example_fabric_billed/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-connection-example-fabric-billed-token
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/connection/example_metal_billed/go/go.mod
+++ b/examples/metal/connection/example_metal_billed/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-connection-example-metal-billed-token
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/connection/example_shared_metal_fabric_connection_from_fcr/go/go.mod
+++ b/examples/metal/connection/example_shared_metal_fabric_connection_from_fcr/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-connection-example_shared_metal_fabric_connection_from_fcr
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/connection/example_shared_metal_fabric_connection_to_csp/go/go.mod
+++ b/examples/metal/connection/example_shared_metal_fabric_connection_to_csp/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-connection-example_shared_metal_fabric_connection_to_csp
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_1/go/go.mod
+++ b/examples/metal/device/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-device-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_2/go/go.mod
+++ b/examples/metal/device/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-device-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_3/go/go.mod
+++ b/examples/metal/device/example_3/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-device-example_3
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_4/go/go.mod
+++ b/examples/metal/device/example_4/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-device-example_4
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_5/go/go.mod
+++ b/examples/metal/device/example_5/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-device-example_5
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device_network_type/go/go.mod
+++ b/examples/metal/device_network_type/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-device-network-type
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/gateway/example_1/go/go.mod
+++ b/examples/metal/gateway/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-gateway-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/gateway/example_2/go/go.mod
+++ b/examples/metal/gateway/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-gateway-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/ip_attachment/go/go.mod
+++ b/examples/metal/ip_attachment/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-ip_attachment
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/metal/organization/go/go.mod
+++ b/examples/metal/organization/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-organization
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/organization_member/example_1/go/go.mod
+++ b/examples/metal/organization_member/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-organization_member-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/organization_member/example_2/go/go.mod
+++ b/examples/metal/organization_member/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-organization_member-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/port_vlan_attachment/example_1/go/go.mod
+++ b/examples/metal/port_vlan_attachment/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-port_vlan_attachment-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/port_vlan_attachment/example_2/go/go.mod
+++ b/examples/metal/port_vlan_attachment/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-port_vlan_attachment-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project/example_1/go/go.mod
+++ b/examples/metal/project/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-project-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project/example_2/go/go.mod
+++ b/examples/metal/project/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-project-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project/example_3/go/go.mod
+++ b/examples/metal/project/example_3/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-project-example_3
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project_api_key/go/go.mod
+++ b/examples/metal/project_api_key/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-project_api_key
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project_ssh_key/go/go.mod
+++ b/examples/metal/project_ssh_key/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-project_ssh_key
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/reserved_ip_block/example_1/go/go.mod
+++ b/examples/metal/reserved_ip_block/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-reserved_ip_block-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/reserved_ip_block/example_2/go/go.mod
+++ b/examples/metal/reserved_ip_block/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-reserved_ip_block-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/spot_market_request/go/go.mod
+++ b/examples/metal/spot_market_request/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-spot_market_request
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/ssh_key/go/go.mod
+++ b/examples/metal/ssh_key/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-ssh_key
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/metal/user_api_key/go/go.mod
+++ b/examples/metal/user_api_key/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-user_api_key
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/virtual_circuit/go/go.mod
+++ b/examples/metal/virtual_circuit/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-virtual_circuit
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/vlan/go/go.mod
+++ b/examples/metal/vlan/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-vlan
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/vrf/example_1/go/go.mod
+++ b/examples/metal/vrf/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-vrf-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/vrf/example_2/go/go.mod
+++ b/examples/metal/vrf/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-vrf-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/vrf/example_3/go/go.mod
+++ b/examples/metal/vrf/example_3/go/go.mod
@@ -2,10 +2,10 @@ module equinix-metal-vrf-example_3
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/acl_template/go/go.mod
+++ b/examples/network/acl_template/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-acl_template
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/bgp/go/go.mod
+++ b/examples/network/bgp/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-bgp
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_1/go/go.mod
+++ b/examples/network/device/example_1/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_1
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_2/go/go.mod
+++ b/examples/network/device/example_2/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_2
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_3/go/go.mod
+++ b/examples/network/device/example_3/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_3
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/network/device/example_4/go/go.mod
+++ b/examples/network/device/example_4/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_4
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_5/go/go.mod
+++ b/examples/network/device/example_5/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_5
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_6/go/go.mod
+++ b/examples/network/device/example_6/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_6
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_7/go/go.mod
+++ b/examples/network/device/example_7/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_7
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_8/go/go.mod
+++ b/examples/network/device/example_8/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_8
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/network/device/example_9/go/go.mod
+++ b/examples/network/device/example_9/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device-example_9
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device_link/go/go.mod
+++ b/examples/network/device_link/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-device_link
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/file/go/go.mod
+++ b/examples/network/file/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-file
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/network/ssh_key/go/go.mod
+++ b/examples/network/ssh_key/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-ssh_key
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/ssh_user/go/go.mod
+++ b/examples/network/ssh_user/go/go.mod
@@ -2,10 +2,10 @@ module equinix-network-ssh_user
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.15.1
+	github.com/equinix/pulumi-equinix/sdk 0.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/patches/0001-pulumi-user-agent.patch
+++ b/patches/0001-pulumi-user-agent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] pulumi user agent
 Signed-off-by: ocobleseqx <oscar.cobles@eu.equinix.com>
 
 diff --git a/internal/config/config.go b/internal/config/config.go
-index 0851398..5b34288 100644
+index 59d002b..2a491de 100644
 --- a/internal/config/config.go
 +++ b/internal/config/config.go
-@@ -339,20 +339,20 @@ func generateModuleUserAgentString(d *schema.ResourceData, baseUserAgent string)
+@@ -310,20 +310,20 @@ func generateModuleUserAgentString(d *schema.ResourceData, baseUserAgent string)
  }
  
  func (c *Config) tfSdkUserAgent(suffix string) string {

--- a/patches/0003-remove-provider-meta.patch
+++ b/patches/0003-remove-provider-meta.patch
@@ -46,10 +46,10 @@ index 4704398..a622712 100644
  	if config.TerraformVersion == "" {
  		// Terraform 0.12 introduced this field to the protocol
 diff --git a/internal/config/config.go b/internal/config/config.go
-index 5b34288..f8e633e 100644
+index 2a491de..9800f9d 100644
 --- a/internal/config/config.go
 +++ b/internal/config/config.go
-@@ -36,10 +36,6 @@ const (
+@@ -34,10 +34,6 @@ const (
  	MetalAuthTokenEnvVar = "METAL_AUTH_TOKEN"
  )
  
@@ -60,7 +60,7 @@ index 5b34288..f8e633e 100644
  const (
  	consumerToken = "aZ9GmqHTPtxevvFq9SK3Pi2yr9YCbRzduCSXF2SNem5sjB91mDq7Th3ZwTtRqMWZ"
  	metalBasePath = "/metal/v1/"
-@@ -307,16 +303,7 @@ func (c *Config) AddFwModuleToMetalUserAgent(ctx context.Context, meta tfsdk.Con
+@@ -278,16 +274,7 @@ func (c *Config) AddFwModuleToMetalUserAgent(ctx context.Context, meta tfsdk.Con
  	c.Metal.UserAgent = generateFwModuleUserAgentString(ctx, meta, c.metalUserAgent)
  }
  
@@ -78,7 +78,7 @@ index 5b34288..f8e633e 100644
  	return baseUserAgent
  }
  
-@@ -324,24 +311,14 @@ func (c *Config) AddModuleToMetalUserAgent(d *schema.ResourceData) {
+@@ -295,24 +282,14 @@ func (c *Config) AddModuleToMetalUserAgent(d *schema.ResourceData) {
  	c.Metal.UserAgent = generateModuleUserAgentString(d, c.metalUserAgent)
  }
  
@@ -105,7 +105,7 @@ index 5b34288..f8e633e 100644
  	baseUserAgent = appendUserAgentFromEnv(baseUserAgent)
  	userAgent := fmt.Sprintf("%s pulumi-equinix/%s %s", baseUserAgent, version.ProviderVersion, suffix)
  	return strings.TrimSpace(userAgent)
-@@ -350,7 +327,7 @@ func (c *Config) tfSdkUserAgent(suffix string) string {
+@@ -321,7 +298,7 @@ func (c *Config) tfSdkUserAgent(suffix string) string {
  func (c *Config) tfFrameworkUserAgent(suffix string) string {
  	frameworkModulePath := "github.com/pulumi/pulumi/pkg/v3"
  	baseUserAgent := fmt.Sprintf("Pulumi/%s (+https://www.pulumi.com) Pulumi Plugin SDK/%s",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/equinix/equinix-sdk-go v0.43.0 // indirect
+	github.com/equinix/equinix-sdk-go v0.44.0 // indirect
 	github.com/equinix/ne-go v1.17.0 // indirect
 	github.com/equinix/oauth2-go v1.0.0 // indirect
 	github.com/equinix/rest-go v1.3.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1370,8 +1370,8 @@ github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6Ni
 github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/envoyproxy/protoc-gen-validate v1.0.1/go.mod h1:0vj8bNkYbSTNS2PIyH87KZaeN4x9zpL9Qt8fQC7d+vs=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
-github.com/equinix/equinix-sdk-go v0.43.0 h1:7i5x6aM1ZDVcIuAr1+yPNSDqsMp1Jye+kVQraGsOBBM=
-github.com/equinix/equinix-sdk-go v0.43.0/go.mod h1:hEb3XLaedz7xhl/dpPIS6eOIiXNPeqNiVoyDrT6paIg=
+github.com/equinix/equinix-sdk-go v0.44.0 h1:v4ejvEGC6TYiwQ29NW4zaq7SlnqLe9SJmfLb4aanbkQ=
+github.com/equinix/equinix-sdk-go v0.44.0/go.mod h1:hEb3XLaedz7xhl/dpPIS6eOIiXNPeqNiVoyDrT6paIg=
 github.com/equinix/ne-go v1.17.0 h1:+wZq0GNognpiTHTsBXtATOCphTFvnowF046NzQXj0n0=
 github.com/equinix/ne-go v1.17.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider equinix/pulumi-equinix --kind=provider --target-bridge-version=latest --pr-title-prefix=feat:  --java-version=0.14.0`.

---

- Updating Java Gen version to 0.14.0.
- Upgrading terraform-provider-equinix from 2.3.3  to 2.4.0.
