### PR TITLE
feat: Upgrade terraform-provider-equinix to v2.4.0

### DIFF
--- a/examples/fabric/cloud_router/go/go.mod
+++ b/examples/fabric/cloud_router/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_fcr_to_azure/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_azure/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_fcr_to_metal/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_metal/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_fcr_to_network/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_network/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_fcr_to_port/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_port/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_metal_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_metal_to_aws/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_port_to_aws/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_network_eplan/go/go.mod
+++ b/examples/fabric/connection/example_port_to_network_eplan/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_network_evplan/go/go.mod
+++ b/examples/fabric/connection/example_port_to_network_evplan/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_port/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_port_access_epl/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port_access_epl/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_port_epl/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port_epl/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_port_to_vd/go/go.mod
+++ b/examples/fabric/connection/example_port_to_vd/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_token_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_token_to_aws/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_vd_to_azure/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_azure/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_vd_to_azure_redundant/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_azure_redundant/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_vd_to_network/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_network/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/connection/example_vd_to_token/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_token/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/network/go/go.mod
+++ b/examples/fabric/network/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/routing_protocol/example_1/go/go.mod
+++ b/examples/fabric/routing_protocol/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/routing_protocol/example_2/go/go.mod
+++ b/examples/fabric/routing_protocol/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/routing_protocol/example_3/go/go.mod
+++ b/examples/fabric/routing_protocol/example_3/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/fabric/service_profile/go/go.mod
+++ b/examples/fabric/service_profile/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/bgp_session/go/go.mod
+++ b/examples/metal/bgp_session/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-null/sdk v0.0.5
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/metal/connection/example_fabric_billed/go/go.mod
+++ b/examples/metal/connection/example_fabric_billed/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/connection/example_metal_billed/go/go.mod
+++ b/examples/metal/connection/example_metal_billed/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/connection/example_shared_metal_fabric_connection_from_fcr/go/go.mod
+++ b/examples/metal/connection/example_shared_metal_fabric_connection_from_fcr/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/connection/example_shared_metal_fabric_connection_to_csp/go/go.mod
+++ b/examples/metal/connection/example_shared_metal_fabric_connection_to_csp/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_1/go/go.mod
+++ b/examples/metal/device/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_2/go/go.mod
+++ b/examples/metal/device/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_3/go/go.mod
+++ b/examples/metal/device/example_3/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_4/go/go.mod
+++ b/examples/metal/device/example_4/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device/example_5/go/go.mod
+++ b/examples/metal/device/example_5/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/device_network_type/go/go.mod
+++ b/examples/metal/device_network_type/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/gateway/example_1/go/go.mod
+++ b/examples/metal/gateway/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/gateway/example_2/go/go.mod
+++ b/examples/metal/gateway/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/ip_attachment/go/go.mod
+++ b/examples/metal/ip_attachment/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/metal/organization/go/go.mod
+++ b/examples/metal/organization/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/organization_member/example_1/go/go.mod
+++ b/examples/metal/organization_member/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/organization_member/example_2/go/go.mod
+++ b/examples/metal/organization_member/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/port_vlan_attachment/example_1/go/go.mod
+++ b/examples/metal/port_vlan_attachment/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/port_vlan_attachment/example_2/go/go.mod
+++ b/examples/metal/port_vlan_attachment/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project/example_1/go/go.mod
+++ b/examples/metal/project/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project/example_2/go/go.mod
+++ b/examples/metal/project/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project/example_3/go/go.mod
+++ b/examples/metal/project/example_3/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project_api_key/go/go.mod
+++ b/examples/metal/project_api_key/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/project_ssh_key/go/go.mod
+++ b/examples/metal/project_ssh_key/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/reserved_ip_block/example_1/go/go.mod
+++ b/examples/metal/reserved_ip_block/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/reserved_ip_block/example_2/go/go.mod
+++ b/examples/metal/reserved_ip_block/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/spot_market_request/go/go.mod
+++ b/examples/metal/spot_market_request/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/ssh_key/go/go.mod
+++ b/examples/metal/ssh_key/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/metal/user_api_key/go/go.mod
+++ b/examples/metal/user_api_key/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/virtual_circuit/go/go.mod
+++ b/examples/metal/virtual_circuit/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/vlan/go/go.mod
+++ b/examples/metal/vlan/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/vrf/example_1/go/go.mod
+++ b/examples/metal/vrf/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/vrf/example_2/go/go.mod
+++ b/examples/metal/vrf/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/metal/vrf/example_3/go/go.mod
+++ b/examples/metal/vrf/example_3/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/acl_template/go/go.mod
+++ b/examples/network/acl_template/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/bgp/go/go.mod
+++ b/examples/network/bgp/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_1/go/go.mod
+++ b/examples/network/device/example_1/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_2/go/go.mod
+++ b/examples/network/device/example_2/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_3/go/go.mod
+++ b/examples/network/device/example_3/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/network/device/example_4/go/go.mod
+++ b/examples/network/device/example_4/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_5/go/go.mod
+++ b/examples/network/device/example_5/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_6/go/go.mod
+++ b/examples/network/device/example_6/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_7/go/go.mod
+++ b/examples/network/device/example_7/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device/example_8/go/go.mod
+++ b/examples/network/device/example_8/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/network/device/example_9/go/go.mod
+++ b/examples/network/device/example_9/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/device_link/go/go.mod
+++ b/examples/network/device_link/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/file/go/go.mod
+++ b/examples/network/file/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )

--- a/examples/network/ssh_key/go/go.mod
+++ b/examples/network/ssh_key/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 

--- a/examples/network/ssh_user/go/go.mod
+++ b/examples/network/ssh_user/go/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.13
 
 require (
-	github.com/equinix/pulumi-equinix/sdk 0.16.2
+	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi/sdk/v3 v3.128.0
 )
 


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider equinix/pulumi-equinix --kind=provider --target-bridge-version=latest --pr-title-prefix=feat:  --java-version=0.14.0`.

---

- Updating Java Gen version to 0.14.0.
- Upgrading terraform-provider-equinix from 2.3.3  to 2.4.0.
