### PR TITLE
chore: renovate to ignorepaths with dotnet files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,6 @@
     "config:base"
   ],
   "ignorePaths": [
-    "sdk/**",
-    "!sdk/go.mod",
-    "!sdk/go.sum"
+    "sdk/**"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,15 @@
   "extends": [
     "config:base"
   ],
+  "ignorePresets": [":ignoreModulesAndTests"],
   "ignorePaths": [
-    "sdk/**"
-  ]
+    "sdk/**",
+    "!sdk/go.mod",
+    "!sdk/go.sum"
+  ],
+  "nuget": {
+    "ignorePaths": [
+      "sdk/dotnet/**"
+    ]
+  }
 }


### PR DESCRIPTION
~The `sdk` folder is completely auto-generated so we don't want `renovate` updating anything there.~
I came across this while checking #196 #197 which I don't understand because "sdk/**" was already specified