### PR TITLE
chore: undo ignore renovate default behavior

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:base"
   ],
-  "ignorePresets": [":ignoreModulesAndTests"],
   "ignorePaths": [
     "sdk/**",
     "!sdk/go.mod",


### PR DESCRIPTION
I misinterpreted the function `ignorePresets` in #202, which actually ignores the default behavior of ignoring [ignoreModulesAndTests](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests). Merging this change should autoclose #203 where renovate is trying to update content in `**/examples/**`