### PR TITLE
chore: run make tfgen

### DIFF
--- a/examples/fabric/cloud_router/example_1/go/go.mod
+++ b/examples/fabric/cloud_router/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/cloud_router/example_2/go/go.mod
+++ b/examples/fabric/cloud_router/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_fcr_to_azure/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_azure/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_fcr_to_metal/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_metal/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_fcr_to_network/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_network/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_fcr_to_port/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_port/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_metal_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_metal_to_aws/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_port_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_port_to_aws/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_port_to_network_eplan/go/go.mod
+++ b/examples/fabric/connection/example_port_to_network_eplan/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_port_to_network_evplan/go/go.mod
+++ b/examples/fabric/connection/example_port_to_network_evplan/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_port_to_port/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_port_to_port_access_epl/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port_access_epl/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_port_to_port_epl/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port_epl/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_port_to_vd/go/go.mod
+++ b/examples/fabric/connection/example_port_to_vd/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_token_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_token_to_aws/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_vd_to_azure/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_azure/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_vd_to_azure_redundant/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_azure_redundant/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_vd_to_network/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_network/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/connection/example_vd_to_token/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_token/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/network/go/go.mod
+++ b/examples/fabric/network/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/routing_protocol/example_1/go/go.mod
+++ b/examples/fabric/routing_protocol/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/routing_protocol/example_2/go/go.mod
+++ b/examples/fabric/routing_protocol/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/routing_protocol/example_3/go/go.mod
+++ b/examples/fabric/routing_protocol/example_3/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/fabric/service_profile/go/go.mod
+++ b/examples/fabric/service_profile/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/bgp_session/csharp/equinix-metal-bgp_session.csproj
+++ b/examples/metal/bgp_session/csharp/equinix-metal-bgp_session.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
 		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
-		<PackageReference Include="Pulumi.Null" Version="0.0.6" />
+		<PackageReference Include="Pulumi.Null" Version="0.0.7" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/bgp_session/go/go.mod
+++ b/examples/metal/bgp_session/go/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi-null/sdk v0.0.6
-	github.com/pulumi/pulumi/sdk/v3 v3.130.0
+	github.com/pulumi/pulumi-null/sdk v0.0.7
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -71,7 +71,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/bgp_session/java/pom.xml
+++ b/examples/metal/bgp_session/java/pom.xml
@@ -30,7 +30,7 @@
         		</dependency><dependency>
             		<groupId>com.pulumi</groupId>
             		<artifactId>null</artifactId>
-            		<version>0.0.6</version>
+            		<version>0.0.7</version>
         		</dependency>
 			</dependencies>
 

--- a/examples/metal/bgp_session/python/requirements.txt
+++ b/examples/metal/bgp_session/python/requirements.txt
@@ -1,3 +1,3 @@
-pulumi-null==0.0.6
+pulumi-null==0.0.7
 pulumi>=3.0.0,<4.0.0
 pulumi_equinix==<1.0.0

--- a/examples/metal/bgp_session/typescript/package.json
+++ b/examples/metal/bgp_session/typescript/package.json
@@ -7,6 +7,6 @@
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
 		"@equinix-labs/pulumi-equinix": "<1.0.0",
-		"@pulumi/null": "0.0.6"
+		"@pulumi/null": "0.0.7"
 	}
 }

--- a/examples/metal/connection/example_shared_metal_fabric_connection_from_fcr/go/go.mod
+++ b/examples/metal/connection/example_shared_metal_fabric_connection_from_fcr/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/connection/example_shared_metal_fabric_connection_to_csp/go/go.mod
+++ b/examples/metal/connection/example_shared_metal_fabric_connection_to_csp/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/device/example_1/go/go.mod
+++ b/examples/metal/device/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/device/example_2/go/go.mod
+++ b/examples/metal/device/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/device/example_3/go/go.mod
+++ b/examples/metal/device/example_3/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/device/example_4/go/go.mod
+++ b/examples/metal/device/example_4/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/device/example_5/go/go.mod
+++ b/examples/metal/device/example_5/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/device_network_type/go/go.mod
+++ b/examples/metal/device_network_type/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -71,7 +71,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/gateway/example_1/go/go.mod
+++ b/examples/metal/gateway/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/gateway/example_2/go/go.mod
+++ b/examples/metal/gateway/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/ip_attachment/go/go.mod
+++ b/examples/metal/ip_attachment/go/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.6
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -71,7 +71,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/organization/go/go.mod
+++ b/examples/metal/organization/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/organization_member/example_1/go/go.mod
+++ b/examples/metal/organization_member/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/organization_member/example_2/go/go.mod
+++ b/examples/metal/organization_member/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/port_vlan_attachment/example_1/go/go.mod
+++ b/examples/metal/port_vlan_attachment/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/port_vlan_attachment/example_2/go/go.mod
+++ b/examples/metal/port_vlan_attachment/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/project/example_1/go/go.mod
+++ b/examples/metal/project/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/project/example_2/go/go.mod
+++ b/examples/metal/project/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/project/example_3/go/go.mod
+++ b/examples/metal/project/example_3/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/project_api_key/go/go.mod
+++ b/examples/metal/project_api_key/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/project_ssh_key/go/go.mod
+++ b/examples/metal/project_ssh_key/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/reserved_ip_block/example_1/go/go.mod
+++ b/examples/metal/reserved_ip_block/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/reserved_ip_block/example_2/go/go.mod
+++ b/examples/metal/reserved_ip_block/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/spot_market_request/go/go.mod
+++ b/examples/metal/spot_market_request/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/ssh_key/go/go.mod
+++ b/examples/metal/ssh_key/go/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.6
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -71,7 +71,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/user_api_key/go/go.mod
+++ b/examples/metal/user_api_key/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/virtual_circuit/go/go.mod
+++ b/examples/metal/virtual_circuit/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/vlan/go/go.mod
+++ b/examples/metal/vlan/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/vrf/example_1/go/go.mod
+++ b/examples/metal/vrf/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/vrf/example_2/go/go.mod
+++ b/examples/metal/vrf/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/metal/vrf/example_3/go/go.mod
+++ b/examples/metal/vrf/example_3/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/acl_template/go/go.mod
+++ b/examples/network/acl_template/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/bgp/go/go.mod
+++ b/examples/network/bgp/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_1/go/go.mod
+++ b/examples/network/device/example_1/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_2/go/go.mod
+++ b/examples/network/device/example_2/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_3/go/go.mod
+++ b/examples/network/device/example_3/go/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.6
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -72,7 +72,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_4/go/go.mod
+++ b/examples/network/device/example_4/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_5/go/go.mod
+++ b/examples/network/device/example_5/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_6/go/go.mod
+++ b/examples/network/device/example_6/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_7/go/go.mod
+++ b/examples/network/device/example_7/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_8/go/go.mod
+++ b/examples/network/device/example_8/go/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.6
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -71,7 +71,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device/example_9/go/go.mod
+++ b/examples/network/device/example_9/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/device_link/go/go.mod
+++ b/examples/network/device_link/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/file/go/go.mod
+++ b/examples/network/file/go/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.6
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
 	github.com/pulumi/pulumi-std/sdk v1.7.3
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -72,7 +72,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/ssh_key/go/go.mod
+++ b/examples/network/ssh_key/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/examples/network/ssh_user/go/go.mod
+++ b/examples/network/ssh_user/go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi/sdk/v3 v3.128.0
+	github.com/pulumi/pulumi/sdk/v3 v3.133.0
 )
 
 require (
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
-	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect


### PR DESCRIPTION
The latest automated provider upgrade PR (#210) includes some unexpected changes to the examples.  It looks like the examples were thrown out-of-sync by an earlier manual PR.  This PR is the result of running `make tfgen` on `main`, and aims to bring the examples back in line with what would be produced by automation.