### PR TITLE
chore(ci): skip mapping errors for acceptance tests

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -22,6 +22,12 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # TODO
   TF_APPEND_USER_AGENT: pulumi
+  # Allow missing or extra mappings due to TF provider
+  # upgrades.  This allows automation to do its job so
+  # that human contributions can be narrowly focused on
+  # adding or removing resource mappings
+  PULUMI_SKIP_MISSING_MAPPING_ERROR: true
+  PULUMI_SKIP_EXTRA_MAPPING_ERROR: true
 jobs:
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||


### PR DESCRIPTION
We recently configured the provider upgrade workflow to skip mapping errors so that hand-written PRs can be smaller & focused on adding/removing resource mappings.  Based on recent provider upgrade PRs it appears that we also need to skip mapping errors in the acceptance tests workflow so that the automated upgrade PRs can pass CI.