### PR TITLE
chore: ensure schema-embed.json is accurate when examples are generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version $(PULUMICTL_BIN)
 provider: tfgen install_plugins # build the provider binary
 provider: only_provider
 
-only_provider: $(PULUMICTL_BIN)
+only_provider: build_schema $(PULUMICTL_BIN)
 	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION} -X github.com/equinix/terraform-provider-equinix/version.ProviderVersion=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
 
 build_sdks: clean build_nodejs build_python build_go build_dotnet build_java # build all the sdks


### PR DESCRIPTION
The example generator script includes some code to replace the current Equinix Pulumi plugin version in generated examples with `< 1.0.0` (or the equivalent per language).  The script uses `.pulumi/bin/pulumictl get version --language generic` to determine the version number that should be replaced.  However, the examples are not necessarily generated to reference that plugin version.  The version referenced in examples appears to come from `provider/cmd/pulumi-resource-equinix/schema-embed.json`.

This adds `build_schema` as a dependency of the `only_provider` Make task.  The `only_provider` task is already a dependency of the `examples` task and the files produced by `build_schema` are necessary for `only_provider`.

This change ensures that the schema files are up-to-date before examples are generated.