### PR TITLE
chore(ci): switch back to official Pulumi upgrade action

### DIFF
--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -42,9 +42,7 @@ jobs:
         ref: ${{ github.ref_name }}
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: equinix-labs/pulumi-upgrade-provider-action@parameterize-go-version
-      #TODO: switch back to upstream when it supports configurable go version
-      #uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.13
       with:
         kind: bridge
         email: noreply@github.com
@@ -57,9 +55,7 @@ jobs:
         go-version-file: provider/go.mod
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: equinix-labs/pulumi-upgrade-provider-action@parameterize-go-version
-      #TODO: switch back to upstream when it supports configurable go version
-      #uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.13
       with:
         kind: bridge
         email: noreply@github.com

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -31,9 +31,7 @@ jobs:
       run: |
         echo "version=$(cat .pulumi-java-gen.version)" >> "$GITHUB_OUTPUT"
     - name: Call upgrade provider action
-      uses: equinix-labs/pulumi-upgrade-provider-action@parameterize-go-version
-      #TODO: switch back to upstream when it supports configurable go version
-      #uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.13
       with:
         kind: provider
         email: noreply@github.com


### PR DESCRIPTION
We briefly switched to a fork of the Pulumi upgrade action in order to use a consistent Go version in all places in our GitHub actions.  The change from our fork has been adopted upstream so we can go back to using the latest release of the official action.