### PR TITLE
feat: Upgrade terraform-provider-equinix to v3.0.1

### DIFF
--- a/examples/fabric/cloud_router/example_1/go/go.mod
+++ b/examples/fabric/cloud_router/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-cloud_router-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/cloud_router/example_2/go/go.mod
+++ b/examples/fabric/cloud_router/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-cloud_router-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_fcr_to_azure/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_azure/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_fcr_to_azure
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_fcr_to_metal/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_metal/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_fcr_to_metal
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_fcr_to_network/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_network/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_fcr_to_network
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_fcr_to_port/go/go.mod
+++ b/examples/fabric/connection/example_fcr_to_port/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_fcr_to_port
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_metal_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_metal_to_aws/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_metal_to_aws
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_port_to_alibaba/go/go.mod
+++ b/examples/fabric/connection/example_port_to_alibaba/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_port_to_alibaba
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_port_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_port_to_aws/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_port_to_aws
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_port_to_network_eplan/go/go.mod
+++ b/examples/fabric/connection/example_port_to_network_eplan/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_port_to_network_eplan
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_port_to_network_evplan/go/go.mod
+++ b/examples/fabric/connection/example_port_to_network_evplan/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_port_to_network_evplan
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_port_to_port/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_port_to_port
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_port_to_port_access_epl/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port_access_epl/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_port_to_port_access_epl
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_port_to_port_epl/go/go.mod
+++ b/examples/fabric/connection/example_port_to_port_epl/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_port_to_port_epl
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_port_to_vd/go/go.mod
+++ b/examples/fabric/connection/example_port_to_vd/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_port_to_vd
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_token_to_aws/go/go.mod
+++ b/examples/fabric/connection/example_token_to_aws/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_token_to_aws
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_vd_to_azure/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_azure/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_vd_to_azure
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_vd_to_azure_redundant/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_azure_redundant/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_vd_to_azure_redundant
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_vd_to_network/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_network/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_vd_to_network
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection/example_vd_to_token/go/go.mod
+++ b/examples/fabric/connection/example_vd_to_token/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection-example_vd_to_token
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/connection_route_filter/go/go.mod
+++ b/examples/fabric/connection_route_filter/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-connection_route_filter
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/network/go/go.mod
+++ b/examples/fabric/network/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-network
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/route_filter_rule/go/go.mod
+++ b/examples/fabric/route_filter_rule/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-route_filter_rule
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/routing_protocol/example_1/go/go.mod
+++ b/examples/fabric/routing_protocol/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-routing_protocol-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/routing_protocol/example_2/go/go.mod
+++ b/examples/fabric/routing_protocol/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-routing_protocol-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/routing_protocol/example_3/go/go.mod
+++ b/examples/fabric/routing_protocol/example_3/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-routing_protocol-example_3
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/service_profile/go/go.mod
+++ b/examples/fabric/service_profile/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-service_profile
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/service_token/example_aside_colo_service_token/go/go.mod
+++ b/examples/fabric/service_token/example_aside_colo_service_token/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-service_token-example_aside_colo_service_token
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/service_token/example_zside_colo_service_token/go/go.mod
+++ b/examples/fabric/service_token/example_zside_colo_service_token/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-service_token-example_zside_colo_service_token
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/fabric/service_token/example_zside_vd_service_token/go/go.mod
+++ b/examples/fabric/service_token/example_zside_vd_service_token/go/go.mod
@@ -2,7 +2,7 @@ module equinix-fabric-service_token-example_zside_vd_service_token
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/bgp_session/csharp/equinix-metal-bgp_session.csproj
+++ b/examples/metal/bgp_session/csharp/equinix-metal-bgp_session.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
 		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
-		<PackageReference Include="Pulumi.Null" Version="0.0.8" />
+		<PackageReference Include="Pulumi.Null" Version="0.0.9" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/bgp_session/go/go.mod
+++ b/examples/metal/bgp_session/go/go.mod
@@ -2,12 +2,12 @@ module equinix-metal-bgp_session
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest
-	github.com/pulumi/pulumi-null/sdk v0.0.8
-	github.com/pulumi/pulumi/sdk/v3 v3.136.1
+	github.com/pulumi/pulumi-null/sdk v0.0.9
+	github.com/pulumi/pulumi/sdk/v3 v3.143.0
 )
 
 require (
@@ -76,14 +76,14 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.14.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/crypto v0.24.0 // indirect
+	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
-	golang.org/x/sys v0.21.0 // indirect
-	golang.org/x/term v0.21.0 // indirect
-	golang.org/x/text v0.16.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/term v0.27.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240311173647-c811ad7063a7 // indirect
 	google.golang.org/grpc v1.63.2 // indirect

--- a/examples/metal/bgp_session/java/pom.xml
+++ b/examples/metal/bgp_session/java/pom.xml
@@ -30,7 +30,7 @@
         		</dependency><dependency>
             		<groupId>com.pulumi</groupId>
             		<artifactId>null</artifactId>
-            		<version>0.0.8</version>
+            		<version>0.0.9</version>
         		</dependency>
 			</dependencies>
 

--- a/examples/metal/bgp_session/python/requirements.txt
+++ b/examples/metal/bgp_session/python/requirements.txt
@@ -1,3 +1,3 @@
-pulumi-null==0.0.8
+pulumi-null==0.0.9
 pulumi>=3.0.0,<4.0.0
 pulumi_equinix==<1.0.0

--- a/examples/metal/bgp_session/typescript/package.json
+++ b/examples/metal/bgp_session/typescript/package.json
@@ -7,6 +7,6 @@
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
 		"@equinix-labs/pulumi-equinix": "<1.0.0",
-		"@pulumi/null": "0.0.8"
+		"@pulumi/null": "0.0.9"
 	}
 }

--- a/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/go/go.mod
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-connection-example_fabric_billed_metal_from_fabric_port
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/connection/example_fabric_billed_metal_from_fcr/go/go.mod
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fcr/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-connection-example_fabric_billed_metal_from_fcr
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/connection/example_fabric_billed_metal_from_network_edge/go/go.mod
+++ b/examples/metal/connection/example_fabric_billed_metal_from_network_edge/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-connection-example_fabric_billed_metal_from_network_edge
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/connection/example_metal_billed_metal_to_fabric_port/go/go.mod
+++ b/examples/metal/connection/example_metal_billed_metal_to_fabric_port/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-connection-example_metal_billed_metal_to_fabric_port
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/device/example_1/go/go.mod
+++ b/examples/metal/device/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-device-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/device/example_2/go/go.mod
+++ b/examples/metal/device/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-device-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/device/example_3/go/go.mod
+++ b/examples/metal/device/example_3/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-device-example_3
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/device/example_4/go/go.mod
+++ b/examples/metal/device/example_4/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-device-example_4
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/device/example_5/go/go.mod
+++ b/examples/metal/device/example_5/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-device-example_5
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/device_network_type/go/go.mod
+++ b/examples/metal/device_network_type/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-device-network-type
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/gateway/example_1/go/go.mod
+++ b/examples/metal/gateway/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-gateway-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/gateway/example_2/go/go.mod
+++ b/examples/metal/gateway/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-gateway-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/ip_attachment/csharp/equinix-metal-ip_attachment.csproj
+++ b/examples/metal/ip_attachment/csharp/equinix-metal-ip_attachment.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/ip_attachment/go/go.mod
+++ b/examples/metal/ip_attachment/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-ip_attachment
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/organization/go/go.mod
+++ b/examples/metal/organization/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-organization
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/organization_member/example_1/go/go.mod
+++ b/examples/metal/organization_member/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-organization_member-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/organization_member/example_2/go/go.mod
+++ b/examples/metal/organization_member/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-organization_member-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/port_vlan_attachment/example_1/go/go.mod
+++ b/examples/metal/port_vlan_attachment/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-port_vlan_attachment-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/port_vlan_attachment/example_2/go/go.mod
+++ b/examples/metal/port_vlan_attachment/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-port_vlan_attachment-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/project/example_1/go/go.mod
+++ b/examples/metal/project/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-project-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/project/example_2/go/go.mod
+++ b/examples/metal/project/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-project-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/project/example_3/go/go.mod
+++ b/examples/metal/project/example_3/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-project-example_3
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/project_api_key/go/go.mod
+++ b/examples/metal/project_api_key/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-project_api_key
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/project_ssh_key/go/go.mod
+++ b/examples/metal/project_ssh_key/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-project_ssh_key
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/reserved_ip_block/example_1/go/go.mod
+++ b/examples/metal/reserved_ip_block/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-reserved_ip_block-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/reserved_ip_block/example_2/go/go.mod
+++ b/examples/metal/reserved_ip_block/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-reserved_ip_block-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/spot_market_request/go/go.mod
+++ b/examples/metal/spot_market_request/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-spot_market_request
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/ssh_key/csharp/equinix-metal-ssh_key.csproj
+++ b/examples/metal/ssh_key/csharp/equinix-metal-ssh_key.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
 		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
+		<PackageReference Include="Pulumi.Std" Version="1.7.3" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/ssh_key/go/go.mod
+++ b/examples/metal/ssh_key/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-ssh_key
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/user_api_key/go/go.mod
+++ b/examples/metal/user_api_key/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-user_api_key
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/virtual_circuit/go/go.mod
+++ b/examples/metal/virtual_circuit/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-virtual_circuit
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/vlan/go/go.mod
+++ b/examples/metal/vlan/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-vlan
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/vrf/example_1/go/go.mod
+++ b/examples/metal/vrf/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-vrf-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/vrf/example_2/go/go.mod
+++ b/examples/metal/vrf/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-vrf-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/metal/vrf/example_3/go/go.mod
+++ b/examples/metal/vrf/example_3/go/go.mod
@@ -2,7 +2,7 @@ module equinix-metal-vrf-example_3
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/acl_template/go/go.mod
+++ b/examples/network/acl_template/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-acl_template
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/bgp/go/go.mod
+++ b/examples/network/bgp/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-bgp
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_1/go/go.mod
+++ b/examples/network/device/example_1/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_1
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_2/go/go.mod
+++ b/examples/network/device/example_2/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_2
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_3/go/go.mod
+++ b/examples/network/device/example_3/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_3
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_4/go/go.mod
+++ b/examples/network/device/example_4/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_4
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_5/go/go.mod
+++ b/examples/network/device/example_5/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_5
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_6/go/go.mod
+++ b/examples/network/device/example_6/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_6
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_7/go/go.mod
+++ b/examples/network/device/example_7/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_7
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_8/go/go.mod
+++ b/examples/network/device/example_8/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_8
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_9/go/go.mod
+++ b/examples/network/device/example_9/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_9
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_Aviatrix_Transit_Edge/go/go.mod
+++ b/examples/network/device/example_Aviatrix_Transit_Edge/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_Aviatrix_Transit_Edge
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/go/go.mod
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_c8000v_byol_with_bandwidth_throughput
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_tier/go/go.mod
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_tier/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_c8000v_byol_with_bandwidth_tier
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_c8000v_byol_without_default_password/go/go.mod
+++ b/examples/network/device/example_c8000v_byol_without_default_password/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_c8000v_byol_without_default_password
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_zscaler_appc/go/go.mod
+++ b/examples/network/device/example_zscaler_appc/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_zscaler_appc
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device/example_zscaler_pse/go/go.mod
+++ b/examples/network/device/example_zscaler_pse/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device-example_zscaler_pse
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/device_link/go/go.mod
+++ b/examples/network/device_link/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-device_link
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/file/go/go.mod
+++ b/examples/network/file/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-file
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/ssh_key/go/go.mod
+++ b/examples/network/ssh_key/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-ssh_key
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest

--- a/examples/network/ssh_user/go/go.mod
+++ b/examples/network/ssh_user/go/go.mod
@@ -2,7 +2,7 @@ module equinix-network-ssh_user
 
 go 1.21
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	github.com/equinix/pulumi-equinix/sdk latest


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider equinix/pulumi-equinix --kind=provider --target-bridge-version=latest --pr-title-prefix=feat:  --java-version=0.16.1`.

---

- Updating Java Gen version to 0.16.1.
- Upgrading terraform-provider-equinix from 3.0.0  to 3.0.1.
