### PR TITLE
chore: update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,13 +30,13 @@ RUN mkdir -p $GOPATH/bin && \
 ENV PATH=$PATH:$GOPATH/bin
 
 # Install pulumictl
-ARG PULUMICTL_VERSION=v0.0.32
+ARG PULUMICTL_VERSION=v0.0.46
 RUN rm -rf /usr/local/bin/pulumictl && \
     wget -O pulumictl.${PULUMICTL_VERSION}.tar.gz https://github.com/pulumi/pulumictl/releases/download/${PULUMICTL_VERSION}/pulumictl-${PULUMICTL_VERSION}-linux-amd64.tar.gz && \
     tar -C /usr/local/bin -xzf pulumictl.${PULUMICTL_VERSION}.tar.gz
 
 # Install nodejs
-ARG NODEJS_VERSION=v16.16.0
+ARG NODEJS_VERSION=v22.13.1
 ARG NODEJS_PKG=node-${NODEJS_VERSION}-linux-x64
 ARG NODEJS_TARBALL=${NODEJS_PKG}.tar.xz
 RUN rm -rf /usr/local/node && \
@@ -66,3 +66,6 @@ RUN apt-get update && \
 # Install Pulumi
 RUN curl -fsSL https://get.pulumi.com | sh
 ENV PATH=$PATH:/root/.pulumi/bin
+
+# Install upgrade-provider
+RUN go install github.com/pulumi/upgrade-provider@main

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && \
     apt-get install -y make && \
     apt-get install -y gcc && \
     apt-get install -y git && \
-    apt-get install -y gh
+    apt-get install -y gh && \
+    apt-get install -y zip
 
 # Install bridged provider prerequisites
 # See README.md
@@ -70,3 +71,12 @@ ENV PATH=$PATH:/root/.pulumi/bin
 
 # Install upgrade-provider
 RUN go install github.com/pulumi/upgrade-provider@main
+
+# Install sdkman
+RUN curl -s "https://get.sdkman.io" | bash
+
+# Install gradle
+SHELL ["/bin/bash", "-c"]
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && \
+    sdk install java && \
+    sdk install gradle

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
     apt-get install -y xz-utils && \
     apt-get install -y make && \
     apt-get install -y gcc && \
-    apt-get install -y git
+    apt-get install -y git && \
+    apt-get install -y gh
 
 # Install bridged provider prerequisites
 # See README.md

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,8 @@
       "dockerfile": "Dockerfile",
       "options": ["--platform=linux/amd64" ]
   },
-  "runArgs": ["--platform=linux/amd64" ]
+  "runArgs": ["--platform=linux/amd64" ],
+  "mounts": [
+    "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh,readonly"
+  ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,8 @@
 {
   "name": "TFProvider",
   "build": {
-      "dockerfile": "Dockerfile"
-  }
+      "dockerfile": "Dockerfile",
+      "options": ["--platform=linux/amd64" ]
+  },
+  "runArgs": ["--platform=linux/amd64" ]
 }


### PR DESCRIPTION
This updates the devcontainer definition so that the dev container can be used instead of installing all of the necessary tools directly on a development machine.