### PR TITLE
chore: clean up unused files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,16 +203,8 @@ test_provider:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init
+	./scripts/upstream.sh init
 endif
-
-upstream.finalize:
-	echo "Deprecated: Use `./upstream.sh format_patches` instead"
-	scripts/upstream_old.sh "$@" end_rebase
-
-upstream.rebase:
-	echo "Deprecated: Use `./upstream.sh checkout` and `./upstream.sh rebase` instead"
-	scripts/upstream_old.sh "$@" start_rebase
 
 .pulumi/bin/pulumi: .pulumi/version
 	@if [ -x .pulumi/bin/pulumi ] && [ "v$$(cat .pulumi/version)" = "$$(.pulumi/bin/pulumi version)" ]; then \

--- a/upstream.sh
+++ b/upstream.sh
@@ -1,1 +1,0 @@
-scripts/upstream.sh


### PR DESCRIPTION
This removes the copy of `upstream.sh` in the repo root as well as some dangling references to the `upstream_old.sh` script that was removed in an earlier PR.