### PR TITLE
chore(ci): alias build_sdks as generate_sdks to fix upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ provider: only_provider
 only_provider: build_schema $(PULUMICTL_BIN)
 	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION} -X github.com/equinix/terraform-provider-equinix/version.ProviderVersion=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
 
-build_sdks: clean build_nodejs build_python build_go build_dotnet build_java # build all the sdks
+generate_sdks build_sdks: clean build_nodejs build_python build_go build_dotnet build_java # build all the sdks
 
 build_nodejs: upstream $(PULUMICTL_BIN)
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --overlays provider/overlays/nodejs --out sdk/nodejs/


### PR DESCRIPTION
A couple months ago, `pulumi/upgrade-provider` was changed to expect the existence of a `generate_sdks` task instead of a `build_sdks` task.  As a result of this change, our provider upgrade workflow is failing.

This follows [the suggestion in a comment on the `upgrade-provider` change PR](https://github.com/pulumi/upgrade-provider/pull/312#issuecomment-2851135278) to alias the `build_sdks` task as `generate_sdks`, which should fix the upgrade workflow.