### PR TITLE
chore(ci): pin version of upgrade-provider to fix failing workflows

### DIFF
--- a/.github/workflows/check-upstream-upgrade.yml
+++ b/.github/workflows/check-upstream-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         tools: go
     - name: Install upgrade-provider
-      run: go install github.com/pulumi/upgrade-provider@main
+      run: go install github.com/pulumi/upgrade-provider@ec62fc8d980f # NOTE: newer upgrade-provider versions do not initialize the upstream submodule
       shell: bash
     - name: "Set up git identity: name"
       run: git config --global user.name GitHub


### PR DESCRIPTION
The [check-upstream-upgrade workflow](https://github.com/equinix/pulumi-equinix/actions/workflows/check-upstream-upgrade.yml) started failing a couple days ago due to a change in the upgrade-provider tool.  For now, this pins the upgrade-provider tool to the last-known good version, taken from the [most recent successful run of check-upstream-upgrade](https://github.com/equinix/pulumi-equinix/actions/runs/16601483698/job/46962077557#step:4:7).