### PR TITLE
chore: upgrade pulumictl to v0.0.50

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN_DIR       := $(WORKING_DIR)/.pulumi/bin
 PULUMICTL_BIN := $(BIN_DIR)/pulumictl
 export PATH := $(BIN_DIR):$(PATH)
 
-PULUMICTL_VERSION := v0.0.46
+PULUMICTL_VERSION := v0.0.50
 
 SHELL            := /bin/bash
 PACK             := equinix


### PR DESCRIPTION
The version we were using, v0.0.46, is almost 2 years old now.  We've upgraded numerous other parts of the toolchain, and I'm upgrading this one now in an attempt to unblock #296.