### PR TITLE
fix: set ProviderVersion for inclusion in the User-Agent

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
     ldflags:
       # The line below MUST align with the module in current provider/go.mod
       - -X github.com/equinix/pulumi-equinix/provider/pkg/version.Version={{.Tag }}
-      - -X github.com/equinix/terraform-provider-equinix/version.ProviderVersion|={{.Tag}}
+      - -X github.com/equinix/terraform-provider-equinix/version.ProviderVersion={{.Version}}
     main: ./cmd/pulumi-resource-equinix/
 changelog:
   disable: true


### PR DESCRIPTION
There was a typo in the goreleaser `ldflags` setting that injects the provider version into the build so that it can be included in the User-Agent string.  As a result, all existing releases of pulumi-equinix include the version `dev` in the User-Agent.

This fixes the goreleaser `ldflags` setting to match what is in [the Equinix Terraform Provider's goreleaser config](https://github.com/equinix/terraform-provider-equinix/blob/408fffdf52b779d5f99a5bfa79fe70d4932d53b9/.goreleaser.yml#L20) so that we can identify usage of different pulumi-equinix versions.