### PR TITLE
chore: run make build again

### DIFF
--- a/examples/fabric/cloud_router/example_1/csharp/equinix-fabric-cloud_router-example_1.csproj
+++ b/examples/fabric/cloud_router/example_1/csharp/equinix-fabric-cloud_router-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/cloud_router/example_1/java/pom.xml
+++ b/examples/fabric/cloud_router/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/cloud_router/example_1/python/requirements.txt
+++ b/examples/fabric/cloud_router/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/cloud_router/example_1/typescript/package.json
+++ b/examples/fabric/cloud_router/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/cloud_router/example_2/csharp/equinix-fabric-cloud_router-example_2.csproj
+++ b/examples/fabric/cloud_router/example_2/csharp/equinix-fabric-cloud_router-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/cloud_router/example_2/java/pom.xml
+++ b/examples/fabric/cloud_router/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/cloud_router/example_2/python/requirements.txt
+++ b/examples/fabric/cloud_router/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/cloud_router/example_2/typescript/package.json
+++ b/examples/fabric/cloud_router/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_fcr_to_azure/csharp/equinix-fabric-connection-example_fcr_to_azure.csproj
+++ b/examples/fabric/connection/example_fcr_to_azure/csharp/equinix-fabric-connection-example_fcr_to_azure.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_fcr_to_azure/java/pom.xml
+++ b/examples/fabric/connection/example_fcr_to_azure/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_fcr_to_azure/python/requirements.txt
+++ b/examples/fabric/connection/example_fcr_to_azure/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_fcr_to_azure/typescript/package.json
+++ b/examples/fabric/connection/example_fcr_to_azure/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_fcr_to_metal/csharp/equinix-fabric-connection-example_fcr_to_metal.csproj
+++ b/examples/fabric/connection/example_fcr_to_metal/csharp/equinix-fabric-connection-example_fcr_to_metal.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_fcr_to_metal/java/pom.xml
+++ b/examples/fabric/connection/example_fcr_to_metal/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_fcr_to_metal/python/requirements.txt
+++ b/examples/fabric/connection/example_fcr_to_metal/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_fcr_to_metal/typescript/package.json
+++ b/examples/fabric/connection/example_fcr_to_metal/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_fcr_to_network/csharp/equinix-fabric-connection-example_fcr_to_network.csproj
+++ b/examples/fabric/connection/example_fcr_to_network/csharp/equinix-fabric-connection-example_fcr_to_network.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_fcr_to_network/java/pom.xml
+++ b/examples/fabric/connection/example_fcr_to_network/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_fcr_to_network/python/requirements.txt
+++ b/examples/fabric/connection/example_fcr_to_network/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_fcr_to_network/typescript/package.json
+++ b/examples/fabric/connection/example_fcr_to_network/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_fcr_to_port/csharp/equinix-fabric-connection-example_fcr_to_port.csproj
+++ b/examples/fabric/connection/example_fcr_to_port/csharp/equinix-fabric-connection-example_fcr_to_port.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_fcr_to_port/java/pom.xml
+++ b/examples/fabric/connection/example_fcr_to_port/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_fcr_to_port/python/requirements.txt
+++ b/examples/fabric/connection/example_fcr_to_port/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_fcr_to_port/typescript/package.json
+++ b/examples/fabric/connection/example_fcr_to_port/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_metal_to_aws/csharp/equinix-fabric-connection-example_metal_to_aws.csproj
+++ b/examples/fabric/connection/example_metal_to_aws/csharp/equinix-fabric-connection-example_metal_to_aws.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_metal_to_aws/java/pom.xml
+++ b/examples/fabric/connection/example_metal_to_aws/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_metal_to_aws/python/requirements.txt
+++ b/examples/fabric/connection/example_metal_to_aws/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_metal_to_aws/typescript/package.json
+++ b/examples/fabric/connection/example_metal_to_aws/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_port_to_alibaba/csharp/equinix-fabric-connection-example_port_to_alibaba.csproj
+++ b/examples/fabric/connection/example_port_to_alibaba/csharp/equinix-fabric-connection-example_port_to_alibaba.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_port_to_alibaba/java/pom.xml
+++ b/examples/fabric/connection/example_port_to_alibaba/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_port_to_alibaba/python/requirements.txt
+++ b/examples/fabric/connection/example_port_to_alibaba/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_port_to_alibaba/typescript/package.json
+++ b/examples/fabric/connection/example_port_to_alibaba/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_port_to_aws/csharp/equinix-fabric-connection-example_port_to_aws.csproj
+++ b/examples/fabric/connection/example_port_to_aws/csharp/equinix-fabric-connection-example_port_to_aws.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_port_to_aws/java/pom.xml
+++ b/examples/fabric/connection/example_port_to_aws/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_port_to_aws/python/requirements.txt
+++ b/examples/fabric/connection/example_port_to_aws/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_port_to_aws/typescript/package.json
+++ b/examples/fabric/connection/example_port_to_aws/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_port_to_network_eplan/csharp/equinix-fabric-connection-example_port_to_network_eplan.csproj
+++ b/examples/fabric/connection/example_port_to_network_eplan/csharp/equinix-fabric-connection-example_port_to_network_eplan.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_port_to_network_eplan/java/pom.xml
+++ b/examples/fabric/connection/example_port_to_network_eplan/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_port_to_network_eplan/python/requirements.txt
+++ b/examples/fabric/connection/example_port_to_network_eplan/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_port_to_network_eplan/typescript/package.json
+++ b/examples/fabric/connection/example_port_to_network_eplan/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_port_to_network_evplan/csharp/equinix-fabric-connection-example_port_to_network_evplan.csproj
+++ b/examples/fabric/connection/example_port_to_network_evplan/csharp/equinix-fabric-connection-example_port_to_network_evplan.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_port_to_network_evplan/java/pom.xml
+++ b/examples/fabric/connection/example_port_to_network_evplan/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_port_to_network_evplan/python/requirements.txt
+++ b/examples/fabric/connection/example_port_to_network_evplan/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_port_to_network_evplan/typescript/package.json
+++ b/examples/fabric/connection/example_port_to_network_evplan/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_port_to_port/csharp/equinix-fabric-connection-example_port_to_port.csproj
+++ b/examples/fabric/connection/example_port_to_port/csharp/equinix-fabric-connection-example_port_to_port.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_port_to_port/java/pom.xml
+++ b/examples/fabric/connection/example_port_to_port/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_port_to_port/python/requirements.txt
+++ b/examples/fabric/connection/example_port_to_port/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_port_to_port/typescript/package.json
+++ b/examples/fabric/connection/example_port_to_port/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_port_to_port_access_epl/csharp/equinix-fabric-connection-example_port_to_port_access_epl.csproj
+++ b/examples/fabric/connection/example_port_to_port_access_epl/csharp/equinix-fabric-connection-example_port_to_port_access_epl.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_port_to_port_access_epl/java/pom.xml
+++ b/examples/fabric/connection/example_port_to_port_access_epl/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_port_to_port_access_epl/python/requirements.txt
+++ b/examples/fabric/connection/example_port_to_port_access_epl/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_port_to_port_access_epl/typescript/package.json
+++ b/examples/fabric/connection/example_port_to_port_access_epl/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_port_to_port_epl/csharp/equinix-fabric-connection-example_port_to_port_epl.csproj
+++ b/examples/fabric/connection/example_port_to_port_epl/csharp/equinix-fabric-connection-example_port_to_port_epl.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_port_to_port_epl/java/pom.xml
+++ b/examples/fabric/connection/example_port_to_port_epl/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_port_to_port_epl/python/requirements.txt
+++ b/examples/fabric/connection/example_port_to_port_epl/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_port_to_port_epl/typescript/package.json
+++ b/examples/fabric/connection/example_port_to_port_epl/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_port_to_vd/csharp/equinix-fabric-connection-example_port_to_vd.csproj
+++ b/examples/fabric/connection/example_port_to_vd/csharp/equinix-fabric-connection-example_port_to_vd.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_port_to_vd/java/pom.xml
+++ b/examples/fabric/connection/example_port_to_vd/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_port_to_vd/python/requirements.txt
+++ b/examples/fabric/connection/example_port_to_vd/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_port_to_vd/typescript/package.json
+++ b/examples/fabric/connection/example_port_to_vd/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_token_to_aws/csharp/equinix-fabric-connection-example_token_to_aws.csproj
+++ b/examples/fabric/connection/example_token_to_aws/csharp/equinix-fabric-connection-example_token_to_aws.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_token_to_aws/java/pom.xml
+++ b/examples/fabric/connection/example_token_to_aws/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_token_to_aws/python/requirements.txt
+++ b/examples/fabric/connection/example_token_to_aws/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_token_to_aws/typescript/package.json
+++ b/examples/fabric/connection/example_token_to_aws/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_vd_to_azure/csharp/equinix-fabric-connection-example_vd_to_azure.csproj
+++ b/examples/fabric/connection/example_vd_to_azure/csharp/equinix-fabric-connection-example_vd_to_azure.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_vd_to_azure/java/pom.xml
+++ b/examples/fabric/connection/example_vd_to_azure/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_vd_to_azure/python/requirements.txt
+++ b/examples/fabric/connection/example_vd_to_azure/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_vd_to_azure/typescript/package.json
+++ b/examples/fabric/connection/example_vd_to_azure/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_vd_to_azure_redundant/csharp/equinix-fabric-connection-example_vd_to_azure_redundant.csproj
+++ b/examples/fabric/connection/example_vd_to_azure_redundant/csharp/equinix-fabric-connection-example_vd_to_azure_redundant.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_vd_to_azure_redundant/java/pom.xml
+++ b/examples/fabric/connection/example_vd_to_azure_redundant/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_vd_to_azure_redundant/python/requirements.txt
+++ b/examples/fabric/connection/example_vd_to_azure_redundant/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_vd_to_azure_redundant/typescript/package.json
+++ b/examples/fabric/connection/example_vd_to_azure_redundant/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_vd_to_network/csharp/equinix-fabric-connection-example_vd_to_network.csproj
+++ b/examples/fabric/connection/example_vd_to_network/csharp/equinix-fabric-connection-example_vd_to_network.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_vd_to_network/java/pom.xml
+++ b/examples/fabric/connection/example_vd_to_network/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_vd_to_network/python/requirements.txt
+++ b/examples/fabric/connection/example_vd_to_network/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_vd_to_network/typescript/package.json
+++ b/examples/fabric/connection/example_vd_to_network/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection/example_vd_to_token/csharp/equinix-fabric-connection-example_vd_to_token.csproj
+++ b/examples/fabric/connection/example_vd_to_token/csharp/equinix-fabric-connection-example_vd_to_token.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection/example_vd_to_token/java/pom.xml
+++ b/examples/fabric/connection/example_vd_to_token/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection/example_vd_to_token/python/requirements.txt
+++ b/examples/fabric/connection/example_vd_to_token/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection/example_vd_to_token/typescript/package.json
+++ b/examples/fabric/connection/example_vd_to_token/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection_route_aggregation/csharp/equinix-fabric-connection_route_aggregation.csproj
+++ b/examples/fabric/connection_route_aggregation/csharp/equinix-fabric-connection_route_aggregation.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection_route_aggregation/java/pom.xml
+++ b/examples/fabric/connection_route_aggregation/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection_route_aggregation/python/requirements.txt
+++ b/examples/fabric/connection_route_aggregation/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection_route_aggregation/typescript/package.json
+++ b/examples/fabric/connection_route_aggregation/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/connection_route_filter/csharp/equinix-fabric-connection_route_filter.csproj
+++ b/examples/fabric/connection_route_filter/csharp/equinix-fabric-connection_route_filter.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/connection_route_filter/java/pom.xml
+++ b/examples/fabric/connection_route_filter/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/connection_route_filter/python/requirements.txt
+++ b/examples/fabric/connection_route_filter/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/connection_route_filter/typescript/package.json
+++ b/examples/fabric/connection_route_filter/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/network/csharp/equinix-fabric-network.csproj
+++ b/examples/fabric/network/csharp/equinix-fabric-network.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/network/java/pom.xml
+++ b/examples/fabric/network/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/network/python/requirements.txt
+++ b/examples/fabric/network/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/network/typescript/package.json
+++ b/examples/fabric/network/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/port/csharp/equinix-fabric-port.csproj
+++ b/examples/fabric/port/csharp/equinix-fabric-port.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/port/java/pom.xml
+++ b/examples/fabric/port/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/port/python/requirements.txt
+++ b/examples/fabric/port/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/port/typescript/package.json
+++ b/examples/fabric/port/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/precision_time_service/csharp/equinix-fabric-precision_time_service.csproj
+++ b/examples/fabric/precision_time_service/csharp/equinix-fabric-precision_time_service.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/precision_time_service/java/pom.xml
+++ b/examples/fabric/precision_time_service/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/precision_time_service/python/requirements.txt
+++ b/examples/fabric/precision_time_service/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/precision_time_service/typescript/package.json
+++ b/examples/fabric/precision_time_service/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/route_aggregation/csharp/equinix-fabric-route_aggregation.csproj
+++ b/examples/fabric/route_aggregation/csharp/equinix-fabric-route_aggregation.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/route_aggregation/java/pom.xml
+++ b/examples/fabric/route_aggregation/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/route_aggregation/python/requirements.txt
+++ b/examples/fabric/route_aggregation/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/route_aggregation/typescript/package.json
+++ b/examples/fabric/route_aggregation/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/route_aggregation_rule/csharp/equinix-fabric-route_aggregation_rule.csproj
+++ b/examples/fabric/route_aggregation_rule/csharp/equinix-fabric-route_aggregation_rule.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/route_aggregation_rule/java/pom.xml
+++ b/examples/fabric/route_aggregation_rule/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/route_aggregation_rule/python/requirements.txt
+++ b/examples/fabric/route_aggregation_rule/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/route_aggregation_rule/typescript/package.json
+++ b/examples/fabric/route_aggregation_rule/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/route_filter_rule/csharp/equinix-fabric-route_filter_rule.csproj
+++ b/examples/fabric/route_filter_rule/csharp/equinix-fabric-route_filter_rule.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/route_filter_rule/java/pom.xml
+++ b/examples/fabric/route_filter_rule/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/route_filter_rule/python/requirements.txt
+++ b/examples/fabric/route_filter_rule/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/route_filter_rule/typescript/package.json
+++ b/examples/fabric/route_filter_rule/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/routing_protocol/example_1/csharp/equinix-fabric-routing_protocol-example_1.csproj
+++ b/examples/fabric/routing_protocol/example_1/csharp/equinix-fabric-routing_protocol-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/routing_protocol/example_1/java/pom.xml
+++ b/examples/fabric/routing_protocol/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/routing_protocol/example_1/python/requirements.txt
+++ b/examples/fabric/routing_protocol/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/routing_protocol/example_1/typescript/package.json
+++ b/examples/fabric/routing_protocol/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/routing_protocol/example_2/csharp/equinix-fabric-routing_protocol-example_2.csproj
+++ b/examples/fabric/routing_protocol/example_2/csharp/equinix-fabric-routing_protocol-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/routing_protocol/example_2/java/pom.xml
+++ b/examples/fabric/routing_protocol/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/routing_protocol/example_2/python/requirements.txt
+++ b/examples/fabric/routing_protocol/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/routing_protocol/example_2/typescript/package.json
+++ b/examples/fabric/routing_protocol/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/routing_protocol/example_3/csharp/equinix-fabric-routing_protocol-example_3.csproj
+++ b/examples/fabric/routing_protocol/example_3/csharp/equinix-fabric-routing_protocol-example_3.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/routing_protocol/example_3/java/pom.xml
+++ b/examples/fabric/routing_protocol/example_3/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/routing_protocol/example_3/python/requirements.txt
+++ b/examples/fabric/routing_protocol/example_3/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/routing_protocol/example_3/typescript/package.json
+++ b/examples/fabric/routing_protocol/example_3/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/service_profile/csharp/equinix-fabric-service_profile.csproj
+++ b/examples/fabric/service_profile/csharp/equinix-fabric-service_profile.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/service_profile/java/pom.xml
+++ b/examples/fabric/service_profile/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/service_profile/python/requirements.txt
+++ b/examples/fabric/service_profile/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/service_profile/typescript/package.json
+++ b/examples/fabric/service_profile/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/service_token/example_aside_colo_service_token/csharp/equinix-fabric-service_token-example_aside_colo_service_token.csproj
+++ b/examples/fabric/service_token/example_aside_colo_service_token/csharp/equinix-fabric-service_token-example_aside_colo_service_token.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/service_token/example_aside_colo_service_token/java/pom.xml
+++ b/examples/fabric/service_token/example_aside_colo_service_token/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/service_token/example_aside_colo_service_token/python/requirements.txt
+++ b/examples/fabric/service_token/example_aside_colo_service_token/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/service_token/example_aside_colo_service_token/typescript/package.json
+++ b/examples/fabric/service_token/example_aside_colo_service_token/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/service_token/example_zside_colo_service_token/csharp/equinix-fabric-service_token-example_zside_colo_service_token.csproj
+++ b/examples/fabric/service_token/example_zside_colo_service_token/csharp/equinix-fabric-service_token-example_zside_colo_service_token.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/service_token/example_zside_colo_service_token/java/pom.xml
+++ b/examples/fabric/service_token/example_zside_colo_service_token/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/service_token/example_zside_colo_service_token/python/requirements.txt
+++ b/examples/fabric/service_token/example_zside_colo_service_token/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/service_token/example_zside_colo_service_token/typescript/package.json
+++ b/examples/fabric/service_token/example_zside_colo_service_token/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/service_token/example_zside_network_service_token/csharp/equinix-fabric-service_token-example_zside_network_service_token.csproj
+++ b/examples/fabric/service_token/example_zside_network_service_token/csharp/equinix-fabric-service_token-example_zside_network_service_token.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/service_token/example_zside_network_service_token/java/pom.xml
+++ b/examples/fabric/service_token/example_zside_network_service_token/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/service_token/example_zside_network_service_token/python/requirements.txt
+++ b/examples/fabric/service_token/example_zside_network_service_token/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/service_token/example_zside_network_service_token/typescript/package.json
+++ b/examples/fabric/service_token/example_zside_network_service_token/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/service_token/example_zside_vd_service_token/csharp/equinix-fabric-service_token-example_zside_vd_service_token.csproj
+++ b/examples/fabric/service_token/example_zside_vd_service_token/csharp/equinix-fabric-service_token-example_zside_vd_service_token.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/service_token/example_zside_vd_service_token/java/pom.xml
+++ b/examples/fabric/service_token/example_zside_vd_service_token/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/service_token/example_zside_vd_service_token/python/requirements.txt
+++ b/examples/fabric/service_token/example_zside_vd_service_token/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/service_token/example_zside_vd_service_token/typescript/package.json
+++ b/examples/fabric/service_token/example_zside_vd_service_token/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/stream/csharp/equinix-fabric-stream.csproj
+++ b/examples/fabric/stream/csharp/equinix-fabric-stream.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/stream/java/pom.xml
+++ b/examples/fabric/stream/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/stream/python/requirements.txt
+++ b/examples/fabric/stream/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/stream/typescript/package.json
+++ b/examples/fabric/stream/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/stream_alert_rule/csharp/equinix-fabric-stream_alert_rule.csproj
+++ b/examples/fabric/stream_alert_rule/csharp/equinix-fabric-stream_alert_rule.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/stream_alert_rule/java/pom.xml
+++ b/examples/fabric/stream_alert_rule/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/stream_alert_rule/python/requirements.txt
+++ b/examples/fabric/stream_alert_rule/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/stream_alert_rule/typescript/package.json
+++ b/examples/fabric/stream_alert_rule/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/fabric/stream_attachment/csharp/equinix-fabric-stream_attachment.csproj
+++ b/examples/fabric/stream_attachment/csharp/equinix-fabric-stream_attachment.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/fabric/stream_attachment/java/pom.xml
+++ b/examples/fabric/stream_attachment/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/fabric/stream_attachment/python/requirements.txt
+++ b/examples/fabric/stream_attachment/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/fabric/stream_attachment/typescript/package.json
+++ b/examples/fabric/stream_attachment/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/bgp_session/csharp/equinix-metal-bgp_session.csproj
+++ b/examples/metal/bgp_session/csharp/equinix-metal-bgp_session.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Null" Version="0.0.9" />
 	</ItemGroup>
 

--- a/examples/metal/bgp_session/java/pom.xml
+++ b/examples/metal/bgp_session/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency><dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>null</artifactId>

--- a/examples/metal/bgp_session/python/requirements.txt
+++ b/examples/metal/bgp_session/python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi-null==0.0.9
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/bgp_session/typescript/package.json
+++ b/examples/metal/bgp_session/typescript/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa",
+		"@equinix-labs/pulumi-equinix": "<1.0.0",
 		"@pulumi/null": "0.0.9"
 	}
 }

--- a/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/csharp/equinix-metal-connection-example_fabric_billed_metal_from_fabric_port.csproj
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/csharp/equinix-metal-connection-example_fabric_billed_metal_from_fabric_port.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/java/pom.xml
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/python/requirements.txt
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/typescript/package.json
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fabric_port/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/connection/example_fabric_billed_metal_from_fcr/csharp/equinix-metal-connection-example_fabric_billed_metal_from_fcr.csproj
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fcr/csharp/equinix-metal-connection-example_fabric_billed_metal_from_fcr.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/connection/example_fabric_billed_metal_from_fcr/java/pom.xml
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fcr/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/connection/example_fabric_billed_metal_from_fcr/python/requirements.txt
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fcr/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/connection/example_fabric_billed_metal_from_fcr/typescript/package.json
+++ b/examples/metal/connection/example_fabric_billed_metal_from_fcr/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/connection/example_fabric_billed_metal_from_network_edge/csharp/equinix-metal-connection-example_fabric_billed_metal_from_network_edge.csproj
+++ b/examples/metal/connection/example_fabric_billed_metal_from_network_edge/csharp/equinix-metal-connection-example_fabric_billed_metal_from_network_edge.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/connection/example_fabric_billed_metal_from_network_edge/java/pom.xml
+++ b/examples/metal/connection/example_fabric_billed_metal_from_network_edge/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/connection/example_fabric_billed_metal_from_network_edge/python/requirements.txt
+++ b/examples/metal/connection/example_fabric_billed_metal_from_network_edge/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/connection/example_fabric_billed_metal_from_network_edge/typescript/package.json
+++ b/examples/metal/connection/example_fabric_billed_metal_from_network_edge/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/connection/example_metal_billed_metal_to_fabric_port/csharp/equinix-metal-connection-example_metal_billed_metal_to_fabric_port.csproj
+++ b/examples/metal/connection/example_metal_billed_metal_to_fabric_port/csharp/equinix-metal-connection-example_metal_billed_metal_to_fabric_port.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/connection/example_metal_billed_metal_to_fabric_port/java/pom.xml
+++ b/examples/metal/connection/example_metal_billed_metal_to_fabric_port/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/connection/example_metal_billed_metal_to_fabric_port/python/requirements.txt
+++ b/examples/metal/connection/example_metal_billed_metal_to_fabric_port/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/connection/example_metal_billed_metal_to_fabric_port/typescript/package.json
+++ b/examples/metal/connection/example_metal_billed_metal_to_fabric_port/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/device/example_1/csharp/equinix-metal-device-example_1.csproj
+++ b/examples/metal/device/example_1/csharp/equinix-metal-device-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/device/example_1/java/pom.xml
+++ b/examples/metal/device/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/device/example_1/python/requirements.txt
+++ b/examples/metal/device/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/device/example_1/typescript/package.json
+++ b/examples/metal/device/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/device/example_2/csharp/equinix-metal-device-example_2.csproj
+++ b/examples/metal/device/example_2/csharp/equinix-metal-device-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/device/example_2/java/pom.xml
+++ b/examples/metal/device/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/device/example_2/python/requirements.txt
+++ b/examples/metal/device/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/device/example_2/typescript/package.json
+++ b/examples/metal/device/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/device/example_3/csharp/equinix-metal-device-example_3.csproj
+++ b/examples/metal/device/example_3/csharp/equinix-metal-device-example_3.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/device/example_3/java/pom.xml
+++ b/examples/metal/device/example_3/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/device/example_3/python/requirements.txt
+++ b/examples/metal/device/example_3/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/device/example_3/typescript/package.json
+++ b/examples/metal/device/example_3/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/device/example_4/csharp/equinix-metal-device-example_4.csproj
+++ b/examples/metal/device/example_4/csharp/equinix-metal-device-example_4.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/device/example_4/java/pom.xml
+++ b/examples/metal/device/example_4/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/device/example_4/python/requirements.txt
+++ b/examples/metal/device/example_4/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/device/example_4/typescript/package.json
+++ b/examples/metal/device/example_4/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/device/example_5/csharp/equinix-metal-device-example_5.csproj
+++ b/examples/metal/device/example_5/csharp/equinix-metal-device-example_5.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/device/example_5/java/pom.xml
+++ b/examples/metal/device/example_5/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/device/example_5/python/requirements.txt
+++ b/examples/metal/device/example_5/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/device/example_5/typescript/package.json
+++ b/examples/metal/device/example_5/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/device_network_type/csharp/equinix-metal-device-network-type.csproj
+++ b/examples/metal/device_network_type/csharp/equinix-metal-device-network-type.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/device_network_type/java/pom.xml
+++ b/examples/metal/device_network_type/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/device_network_type/python/requirements.txt
+++ b/examples/metal/device_network_type/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/device_network_type/typescript/package.json
+++ b/examples/metal/device_network_type/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/gateway/example_1/csharp/equinix-metal-gateway-example_1.csproj
+++ b/examples/metal/gateway/example_1/csharp/equinix-metal-gateway-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/gateway/example_1/java/pom.xml
+++ b/examples/metal/gateway/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/gateway/example_1/python/requirements.txt
+++ b/examples/metal/gateway/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/gateway/example_1/typescript/package.json
+++ b/examples/metal/gateway/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/gateway/example_2/csharp/equinix-metal-gateway-example_2.csproj
+++ b/examples/metal/gateway/example_2/csharp/equinix-metal-gateway-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/gateway/example_2/java/pom.xml
+++ b/examples/metal/gateway/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/gateway/example_2/python/requirements.txt
+++ b/examples/metal/gateway/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/gateway/example_2/typescript/package.json
+++ b/examples/metal/gateway/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/ip_attachment/csharp/equinix-metal-ip_attachment.csproj
+++ b/examples/metal/ip_attachment/csharp/equinix-metal-ip_attachment.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Std" Version="2.1.0" />
 	</ItemGroup>
 

--- a/examples/metal/ip_attachment/java/pom.xml
+++ b/examples/metal/ip_attachment/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency><dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>std</artifactId>

--- a/examples/metal/ip_attachment/python/requirements.txt
+++ b/examples/metal/ip_attachment/python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi-std==2.1.0
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/ip_attachment/typescript/package.json
+++ b/examples/metal/ip_attachment/typescript/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa",
+		"@equinix-labs/pulumi-equinix": "<1.0.0",
 		"@pulumi/std": "2.1.0"
 	}
 }

--- a/examples/metal/organization/csharp/equinix-metal-organization.csproj
+++ b/examples/metal/organization/csharp/equinix-metal-organization.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/organization/java/pom.xml
+++ b/examples/metal/organization/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/organization/python/requirements.txt
+++ b/examples/metal/organization/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/organization/typescript/package.json
+++ b/examples/metal/organization/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/organization_member/example_1/csharp/equinix-metal-organization_member-example_1.csproj
+++ b/examples/metal/organization_member/example_1/csharp/equinix-metal-organization_member-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/organization_member/example_1/java/pom.xml
+++ b/examples/metal/organization_member/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/organization_member/example_1/python/requirements.txt
+++ b/examples/metal/organization_member/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/organization_member/example_1/typescript/package.json
+++ b/examples/metal/organization_member/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/organization_member/example_2/csharp/equinix-metal-organization_member-example_2.csproj
+++ b/examples/metal/organization_member/example_2/csharp/equinix-metal-organization_member-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/organization_member/example_2/java/pom.xml
+++ b/examples/metal/organization_member/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/organization_member/example_2/python/requirements.txt
+++ b/examples/metal/organization_member/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/organization_member/example_2/typescript/package.json
+++ b/examples/metal/organization_member/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/port_vlan_attachment/example_1/csharp/equinix-metal-port_vlan_attachment-example_1.csproj
+++ b/examples/metal/port_vlan_attachment/example_1/csharp/equinix-metal-port_vlan_attachment-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/port_vlan_attachment/example_1/java/pom.xml
+++ b/examples/metal/port_vlan_attachment/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/port_vlan_attachment/example_1/python/requirements.txt
+++ b/examples/metal/port_vlan_attachment/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/port_vlan_attachment/example_1/typescript/package.json
+++ b/examples/metal/port_vlan_attachment/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/port_vlan_attachment/example_2/csharp/equinix-metal-port_vlan_attachment-example_2.csproj
+++ b/examples/metal/port_vlan_attachment/example_2/csharp/equinix-metal-port_vlan_attachment-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/port_vlan_attachment/example_2/java/pom.xml
+++ b/examples/metal/port_vlan_attachment/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/port_vlan_attachment/example_2/python/requirements.txt
+++ b/examples/metal/port_vlan_attachment/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/port_vlan_attachment/example_2/typescript/package.json
+++ b/examples/metal/port_vlan_attachment/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/project/example_1/csharp/equinix-metal-project-example_1.csproj
+++ b/examples/metal/project/example_1/csharp/equinix-metal-project-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/project/example_1/java/pom.xml
+++ b/examples/metal/project/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/project/example_1/python/requirements.txt
+++ b/examples/metal/project/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/project/example_1/typescript/package.json
+++ b/examples/metal/project/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/project/example_2/csharp/equinix-metal-project-example_2.csproj
+++ b/examples/metal/project/example_2/csharp/equinix-metal-project-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/project/example_2/java/pom.xml
+++ b/examples/metal/project/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/project/example_2/python/requirements.txt
+++ b/examples/metal/project/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/project/example_2/typescript/package.json
+++ b/examples/metal/project/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/project/example_3/csharp/equinix-metal-project-example_3.csproj
+++ b/examples/metal/project/example_3/csharp/equinix-metal-project-example_3.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/project/example_3/java/pom.xml
+++ b/examples/metal/project/example_3/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/project/example_3/python/requirements.txt
+++ b/examples/metal/project/example_3/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/project/example_3/typescript/package.json
+++ b/examples/metal/project/example_3/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/project_api_key/csharp/equinix-metal-project_api_key.csproj
+++ b/examples/metal/project_api_key/csharp/equinix-metal-project_api_key.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/project_api_key/java/pom.xml
+++ b/examples/metal/project_api_key/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/project_api_key/python/requirements.txt
+++ b/examples/metal/project_api_key/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/project_api_key/typescript/package.json
+++ b/examples/metal/project_api_key/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/project_ssh_key/csharp/equinix-metal-project_ssh_key.csproj
+++ b/examples/metal/project_ssh_key/csharp/equinix-metal-project_ssh_key.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/project_ssh_key/java/pom.xml
+++ b/examples/metal/project_ssh_key/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/project_ssh_key/python/requirements.txt
+++ b/examples/metal/project_ssh_key/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/project_ssh_key/typescript/package.json
+++ b/examples/metal/project_ssh_key/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/reserved_ip_block/example_1/csharp/equinix-metal-reserved_ip_block-example_1.csproj
+++ b/examples/metal/reserved_ip_block/example_1/csharp/equinix-metal-reserved_ip_block-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/reserved_ip_block/example_1/java/pom.xml
+++ b/examples/metal/reserved_ip_block/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/reserved_ip_block/example_1/python/requirements.txt
+++ b/examples/metal/reserved_ip_block/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/reserved_ip_block/example_1/typescript/package.json
+++ b/examples/metal/reserved_ip_block/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/reserved_ip_block/example_2/csharp/equinix-metal-reserved_ip_block-example_2.csproj
+++ b/examples/metal/reserved_ip_block/example_2/csharp/equinix-metal-reserved_ip_block-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/reserved_ip_block/example_2/java/pom.xml
+++ b/examples/metal/reserved_ip_block/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/reserved_ip_block/example_2/python/requirements.txt
+++ b/examples/metal/reserved_ip_block/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/reserved_ip_block/example_2/typescript/package.json
+++ b/examples/metal/reserved_ip_block/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/ssh_key/csharp/equinix-metal-ssh_key.csproj
+++ b/examples/metal/ssh_key/csharp/equinix-metal-ssh_key.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
 		<PackageReference Include="Pulumi.Std" Version="2.1.0" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/ssh_key/java/pom.xml
+++ b/examples/metal/ssh_key/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency><dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>std</artifactId>

--- a/examples/metal/ssh_key/python/requirements.txt
+++ b/examples/metal/ssh_key/python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi-std==2.1.0
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/ssh_key/typescript/package.json
+++ b/examples/metal/ssh_key/typescript/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa",
+		"@equinix-labs/pulumi-equinix": "<1.0.0",
 		"@pulumi/std": "2.1.0"
 	}
 }

--- a/examples/metal/user_api_key/csharp/equinix-metal-user_api_key.csproj
+++ b/examples/metal/user_api_key/csharp/equinix-metal-user_api_key.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/user_api_key/java/pom.xml
+++ b/examples/metal/user_api_key/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/user_api_key/python/requirements.txt
+++ b/examples/metal/user_api_key/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/user_api_key/typescript/package.json
+++ b/examples/metal/user_api_key/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/virtual_circuit/csharp/equinix-metal-virtual_circuit.csproj
+++ b/examples/metal/virtual_circuit/csharp/equinix-metal-virtual_circuit.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/virtual_circuit/java/pom.xml
+++ b/examples/metal/virtual_circuit/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/virtual_circuit/python/requirements.txt
+++ b/examples/metal/virtual_circuit/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/virtual_circuit/typescript/package.json
+++ b/examples/metal/virtual_circuit/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/vlan/csharp/equinix-metal-vlan.csproj
+++ b/examples/metal/vlan/csharp/equinix-metal-vlan.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/vlan/java/pom.xml
+++ b/examples/metal/vlan/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/vlan/python/requirements.txt
+++ b/examples/metal/vlan/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/vlan/typescript/package.json
+++ b/examples/metal/vlan/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/vrf/example_1/csharp/equinix-metal-vrf-example_1.csproj
+++ b/examples/metal/vrf/example_1/csharp/equinix-metal-vrf-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/vrf/example_1/java/pom.xml
+++ b/examples/metal/vrf/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/vrf/example_1/python/requirements.txt
+++ b/examples/metal/vrf/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/vrf/example_1/typescript/package.json
+++ b/examples/metal/vrf/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/vrf/example_2/csharp/equinix-metal-vrf-example_2.csproj
+++ b/examples/metal/vrf/example_2/csharp/equinix-metal-vrf-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/vrf/example_2/java/pom.xml
+++ b/examples/metal/vrf/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/vrf/example_2/python/requirements.txt
+++ b/examples/metal/vrf/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/vrf/example_2/typescript/package.json
+++ b/examples/metal/vrf/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/metal/vrf/example_3/csharp/equinix-metal-vrf-example_3.csproj
+++ b/examples/metal/vrf/example_3/csharp/equinix-metal-vrf-example_3.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/metal/vrf/example_3/java/pom.xml
+++ b/examples/metal/vrf/example_3/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/metal/vrf/example_3/python/requirements.txt
+++ b/examples/metal/vrf/example_3/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/metal/vrf/example_3/typescript/package.json
+++ b/examples/metal/vrf/example_3/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/acl_template/csharp/equinix-network-acl_template.csproj
+++ b/examples/network/acl_template/csharp/equinix-network-acl_template.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/acl_template/java/pom.xml
+++ b/examples/network/acl_template/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/acl_template/python/requirements.txt
+++ b/examples/network/acl_template/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/acl_template/typescript/package.json
+++ b/examples/network/acl_template/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/bgp/csharp/equinix-network-bgp.csproj
+++ b/examples/network/bgp/csharp/equinix-network-bgp.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/bgp/java/pom.xml
+++ b/examples/network/bgp/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/bgp/python/requirements.txt
+++ b/examples/network/bgp/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/bgp/typescript/package.json
+++ b/examples/network/bgp/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_1/csharp/equinix-network-device-example_1.csproj
+++ b/examples/network/device/example_1/csharp/equinix-network-device-example_1.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_1/java/pom.xml
+++ b/examples/network/device/example_1/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_1/python/requirements.txt
+++ b/examples/network/device/example_1/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_1/typescript/package.json
+++ b/examples/network/device/example_1/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_2/csharp/equinix-network-device-example_2.csproj
+++ b/examples/network/device/example_2/csharp/equinix-network-device-example_2.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_2/java/pom.xml
+++ b/examples/network/device/example_2/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_2/python/requirements.txt
+++ b/examples/network/device/example_2/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_2/typescript/package.json
+++ b/examples/network/device/example_2/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_3/csharp/equinix-network-device-example_3.csproj
+++ b/examples/network/device/example_3/csharp/equinix-network-device-example_3.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Std" Version="2.1.0" />
 	</ItemGroup>
 

--- a/examples/network/device/example_3/java/pom.xml
+++ b/examples/network/device/example_3/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency><dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>std</artifactId>

--- a/examples/network/device/example_3/python/requirements.txt
+++ b/examples/network/device/example_3/python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi-std==2.1.0
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_3/typescript/package.json
+++ b/examples/network/device/example_3/typescript/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa",
+		"@equinix-labs/pulumi-equinix": "<1.0.0",
 		"@pulumi/std": "2.1.0"
 	}
 }

--- a/examples/network/device/example_4/csharp/equinix-network-device-example_4.csproj
+++ b/examples/network/device/example_4/csharp/equinix-network-device-example_4.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_4/java/pom.xml
+++ b/examples/network/device/example_4/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_4/python/requirements.txt
+++ b/examples/network/device/example_4/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_4/typescript/package.json
+++ b/examples/network/device/example_4/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_5/csharp/equinix-network-device-example_5.csproj
+++ b/examples/network/device/example_5/csharp/equinix-network-device-example_5.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_5/java/pom.xml
+++ b/examples/network/device/example_5/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_5/python/requirements.txt
+++ b/examples/network/device/example_5/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_5/typescript/package.json
+++ b/examples/network/device/example_5/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_6/csharp/equinix-network-device-example_6.csproj
+++ b/examples/network/device/example_6/csharp/equinix-network-device-example_6.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_6/java/pom.xml
+++ b/examples/network/device/example_6/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_6/python/requirements.txt
+++ b/examples/network/device/example_6/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_6/typescript/package.json
+++ b/examples/network/device/example_6/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_7/csharp/equinix-network-device-example_7.csproj
+++ b/examples/network/device/example_7/csharp/equinix-network-device-example_7.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_7/java/pom.xml
+++ b/examples/network/device/example_7/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_7/python/requirements.txt
+++ b/examples/network/device/example_7/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_7/typescript/package.json
+++ b/examples/network/device/example_7/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_8/csharp/equinix-network-device-example_8.csproj
+++ b/examples/network/device/example_8/csharp/equinix-network-device-example_8.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Std" Version="2.1.0" />
 	</ItemGroup>
 

--- a/examples/network/device/example_8/java/pom.xml
+++ b/examples/network/device/example_8/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency><dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>std</artifactId>

--- a/examples/network/device/example_8/python/requirements.txt
+++ b/examples/network/device/example_8/python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi-std==2.1.0
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_8/typescript/package.json
+++ b/examples/network/device/example_8/typescript/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa",
+		"@equinix-labs/pulumi-equinix": "<1.0.0",
 		"@pulumi/std": "2.1.0"
 	}
 }

--- a/examples/network/device/example_9/csharp/equinix-network-device-example_9.csproj
+++ b/examples/network/device/example_9/csharp/equinix-network-device-example_9.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_9/java/pom.xml
+++ b/examples/network/device/example_9/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_9/python/requirements.txt
+++ b/examples/network/device/example_9/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_9/typescript/package.json
+++ b/examples/network/device/example_9/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_Aviatrix_Transit_Edge/csharp/equinix-network-device-example_Aviatrix_Transit_Edge.csproj
+++ b/examples/network/device/example_Aviatrix_Transit_Edge/csharp/equinix-network-device-example_Aviatrix_Transit_Edge.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Std" Version="2.1.0" />
 	</ItemGroup>
 

--- a/examples/network/device/example_Aviatrix_Transit_Edge/java/pom.xml
+++ b/examples/network/device/example_Aviatrix_Transit_Edge/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency><dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>std</artifactId>

--- a/examples/network/device/example_Aviatrix_Transit_Edge/python/requirements.txt
+++ b/examples/network/device/example_Aviatrix_Transit_Edge/python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi-std==2.1.0
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_Aviatrix_Transit_Edge/typescript/package.json
+++ b/examples/network/device/example_Aviatrix_Transit_Edge/typescript/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa",
+		"@equinix-labs/pulumi-equinix": "<1.0.0",
 		"@pulumi/std": "2.1.0"
 	}
 }

--- a/examples/network/device/example_aruba_edgeconnect_ha_device/csharp/equinix-network-device-example_aruba_edgeconnect_ha_device.csproj
+++ b/examples/network/device/example_aruba_edgeconnect_ha_device/csharp/equinix-network-device-example_aruba_edgeconnect_ha_device.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_aruba_edgeconnect_ha_device/java/pom.xml
+++ b/examples/network/device/example_aruba_edgeconnect_ha_device/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_aruba_edgeconnect_ha_device/python/requirements.txt
+++ b/examples/network/device/example_aruba_edgeconnect_ha_device/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_aruba_edgeconnect_ha_device/typescript/package.json
+++ b/examples/network/device/example_aruba_edgeconnect_ha_device/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_aruba_edgeconnect_ha_device_wth_purchase_order/csharp/equinix-network-device-example_aruba_edgeconnect_ha_device_wth_purchase_order.csproj
+++ b/examples/network/device/example_aruba_edgeconnect_ha_device_wth_purchase_order/csharp/equinix-network-device-example_aruba_edgeconnect_ha_device_wth_purchase_order.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_aruba_edgeconnect_ha_device_wth_purchase_order/java/pom.xml
+++ b/examples/network/device/example_aruba_edgeconnect_ha_device_wth_purchase_order/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_aruba_edgeconnect_ha_device_wth_purchase_order/python/requirements.txt
+++ b/examples/network/device/example_aruba_edgeconnect_ha_device_wth_purchase_order/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_aruba_edgeconnect_ha_device_wth_purchase_order/typescript/package.json
+++ b/examples/network/device/example_aruba_edgeconnect_ha_device_wth_purchase_order/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/csharp/equinix-network-device-example_c8000v_byol_with_bandwidth_throughput.csproj
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/csharp/equinix-network-device-example_c8000v_byol_with_bandwidth_throughput.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/java/pom.xml
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/python/requirements.txt
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/typescript/package.json
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_throughput/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_tier/csharp/equinix-network-device-example_c8000v_byol_with_bandwidth_tier.csproj
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_tier/csharp/equinix-network-device-example_c8000v_byol_with_bandwidth_tier.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_tier/java/pom.xml
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_tier/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_tier/python/requirements.txt
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_tier/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_c8000v_byol_with_bandwidth_tier/typescript/package.json
+++ b/examples/network/device/example_c8000v_byol_with_bandwidth_tier/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_c8000v_byol_without_default_password/csharp/equinix-network-device-example_c8000v_byol_without_default_password.csproj
+++ b/examples/network/device/example_c8000v_byol_without_default_password/csharp/equinix-network-device-example_c8000v_byol_without_default_password.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_c8000v_byol_without_default_password/java/pom.xml
+++ b/examples/network/device/example_c8000v_byol_without_default_password/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_c8000v_byol_without_default_password/python/requirements.txt
+++ b/examples/network/device/example_c8000v_byol_without_default_password/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_c8000v_byol_without_default_password/typescript/package.json
+++ b/examples/network/device/example_c8000v_byol_without_default_password/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_c8000v_ha_with_cloud_init_rest_api_support/csharp/equinix-network-device-example_c8000v_ha_with_cloud_init_rest_api_support.csproj
+++ b/examples/network/device/example_c8000v_ha_with_cloud_init_rest_api_support/csharp/equinix-network-device-example_c8000v_ha_with_cloud_init_rest_api_support.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_c8000v_ha_with_cloud_init_rest_api_support/java/pom.xml
+++ b/examples/network/device/example_c8000v_ha_with_cloud_init_rest_api_support/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_c8000v_ha_with_cloud_init_rest_api_support/python/requirements.txt
+++ b/examples/network/device/example_c8000v_ha_with_cloud_init_rest_api_support/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_c8000v_ha_with_cloud_init_rest_api_support/typescript/package.json
+++ b/examples/network/device/example_c8000v_ha_with_cloud_init_rest_api_support/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_checkpoint_single_device/csharp/equinix-network-device-example_checkpoint_single_device.csproj
+++ b/examples/network/device/example_checkpoint_single_device/csharp/equinix-network-device-example_checkpoint_single_device.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_checkpoint_single_device/java/pom.xml
+++ b/examples/network/device/example_checkpoint_single_device/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_checkpoint_single_device/python/requirements.txt
+++ b/examples/network/device/example_checkpoint_single_device/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_checkpoint_single_device/typescript/package.json
+++ b/examples/network/device/example_checkpoint_single_device/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_cisco_ftd_cluster_znpd/csharp/equinix-network-device-example_cisco_ftd_cluster_znpd.csproj
+++ b/examples/network/device/example_cisco_ftd_cluster_znpd/csharp/equinix-network-device-example_cisco_ftd_cluster_znpd.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_cisco_ftd_cluster_znpd/java/pom.xml
+++ b/examples/network/device/example_cisco_ftd_cluster_znpd/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_cisco_ftd_cluster_znpd/python/requirements.txt
+++ b/examples/network/device/example_cisco_ftd_cluster_znpd/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_cisco_ftd_cluster_znpd/typescript/package.json
+++ b/examples/network/device/example_cisco_ftd_cluster_znpd/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_f5xc_single/csharp/equinix-network-device-example_f5xc_single.csproj
+++ b/examples/network/device/example_f5xc_single/csharp/equinix-network-device-example_f5xc_single.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_f5xc_single/java/pom.xml
+++ b/examples/network/device/example_f5xc_single/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_f5xc_single/python/requirements.txt
+++ b/examples/network/device/example_f5xc_single/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_f5xc_single/typescript/package.json
+++ b/examples/network/device/example_f5xc_single/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_fortigate_sdwan_single_device/csharp/equinix-network-device-example_fortigate_sdwan_single_device.csproj
+++ b/examples/network/device/example_fortigate_sdwan_single_device/csharp/equinix-network-device-example_fortigate_sdwan_single_device.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_fortigate_sdwan_single_device/java/pom.xml
+++ b/examples/network/device/example_fortigate_sdwan_single_device/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_fortigate_sdwan_single_device/python/requirements.txt
+++ b/examples/network/device/example_fortigate_sdwan_single_device/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_fortigate_sdwan_single_device/typescript/package.json
+++ b/examples/network/device/example_fortigate_sdwan_single_device/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_infoblox_cluster_device/csharp/equinix-network-device-example_infoblox_cluster_device.csproj
+++ b/examples/network/device/example_infoblox_cluster_device/csharp/equinix-network-device-example_infoblox_cluster_device.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_infoblox_cluster_device/java/pom.xml
+++ b/examples/network/device/example_infoblox_cluster_device/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_infoblox_cluster_device/python/requirements.txt
+++ b/examples/network/device/example_infoblox_cluster_device/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_infoblox_cluster_device/typescript/package.json
+++ b/examples/network/device/example_infoblox_cluster_device/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_infoblox_ha_device/csharp/equinix-network-device-example_infoblox_ha_device.csproj
+++ b/examples/network/device/example_infoblox_ha_device/csharp/equinix-network-device-example_infoblox_ha_device.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_infoblox_ha_device/java/pom.xml
+++ b/examples/network/device/example_infoblox_ha_device/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_infoblox_ha_device/python/requirements.txt
+++ b/examples/network/device/example_infoblox_ha_device/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_infoblox_ha_device/typescript/package.json
+++ b/examples/network/device/example_infoblox_ha_device/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_infoblox_single_device/csharp/equinix-network-device-example_infoblox_single_device.csproj
+++ b/examples/network/device/example_infoblox_single_device/csharp/equinix-network-device-example_infoblox_single_device.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_infoblox_single_device/java/pom.xml
+++ b/examples/network/device/example_infoblox_single_device/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_infoblox_single_device/python/requirements.txt
+++ b/examples/network/device/example_infoblox_single_device/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_infoblox_single_device/typescript/package.json
+++ b/examples/network/device/example_infoblox_single_device/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_versa_sdwan_ha_device/csharp/equinix-network-device-example_versa_sdwan_ha_device.csproj
+++ b/examples/network/device/example_versa_sdwan_ha_device/csharp/equinix-network-device-example_versa_sdwan_ha_device.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_versa_sdwan_ha_device/java/pom.xml
+++ b/examples/network/device/example_versa_sdwan_ha_device/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_versa_sdwan_ha_device/python/requirements.txt
+++ b/examples/network/device/example_versa_sdwan_ha_device/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_versa_sdwan_ha_device/typescript/package.json
+++ b/examples/network/device/example_versa_sdwan_ha_device/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_vyos_router_ha_device/csharp/equinix-network-device-example_vyos_router_ha_device.csproj
+++ b/examples/network/device/example_vyos_router_ha_device/csharp/equinix-network-device-example_vyos_router_ha_device.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_vyos_router_ha_device/java/pom.xml
+++ b/examples/network/device/example_vyos_router_ha_device/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_vyos_router_ha_device/python/requirements.txt
+++ b/examples/network/device/example_vyos_router_ha_device/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_vyos_router_ha_device/typescript/package.json
+++ b/examples/network/device/example_vyos_router_ha_device/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_zscaler_appc/csharp/equinix-network-device-example_zscaler_appc.csproj
+++ b/examples/network/device/example_zscaler_appc/csharp/equinix-network-device-example_zscaler_appc.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_zscaler_appc/java/pom.xml
+++ b/examples/network/device/example_zscaler_appc/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_zscaler_appc/python/requirements.txt
+++ b/examples/network/device/example_zscaler_appc/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_zscaler_appc/typescript/package.json
+++ b/examples/network/device/example_zscaler_appc/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device/example_zscaler_pse/csharp/equinix-network-device-example_zscaler_pse.csproj
+++ b/examples/network/device/example_zscaler_pse/csharp/equinix-network-device-example_zscaler_pse.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device/example_zscaler_pse/java/pom.xml
+++ b/examples/network/device/example_zscaler_pse/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device/example_zscaler_pse/python/requirements.txt
+++ b/examples/network/device/example_zscaler_pse/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device/example_zscaler_pse/typescript/package.json
+++ b/examples/network/device/example_zscaler_pse/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/device_link/csharp/equinix-network-device_link.csproj
+++ b/examples/network/device_link/csharp/equinix-network-device_link.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/device_link/java/pom.xml
+++ b/examples/network/device_link/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/device_link/python/requirements.txt
+++ b/examples/network/device_link/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/device_link/typescript/package.json
+++ b/examples/network/device_link/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/file/csharp/equinix-network-file.csproj
+++ b/examples/network/file/csharp/equinix-network-file.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 		<PackageReference Include="Pulumi.Std" Version="2.1.0" />
 	</ItemGroup>
 

--- a/examples/network/file/java/pom.xml
+++ b/examples/network/file/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency><dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>std</artifactId>

--- a/examples/network/file/python/requirements.txt
+++ b/examples/network/file/python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi-std==2.1.0
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/file/typescript/package.json
+++ b/examples/network/file/typescript/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa",
+		"@equinix-labs/pulumi-equinix": "<1.0.0",
 		"@pulumi/std": "2.1.0"
 	}
 }

--- a/examples/network/ssh_key/csharp/equinix-network-ssh_key.csproj
+++ b/examples/network/ssh_key/csharp/equinix-network-ssh_key.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/ssh_key/java/pom.xml
+++ b/examples/network/ssh_key/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/ssh_key/python/requirements.txt
+++ b/examples/network/ssh_key/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/ssh_key/typescript/package.json
+++ b/examples/network/ssh_key/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/examples/network/ssh_user/csharp/equinix-network-ssh_user.csproj
+++ b/examples/network/ssh_user/csharp/equinix-network-ssh_user.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Equinix" Version="0.27.2-alpha.1765320197+d4b1ddfa" />
+		<PackageReference Include="Pulumi.Equinix" Version="(, 1.0.0)" />
 	</ItemGroup>
 
 </Project>

--- a/examples/network/ssh_user/java/pom.xml
+++ b/examples/network/ssh_user/java/pom.xml
@@ -26,7 +26,7 @@
 				<dependency>
 					<groupId>com.pulumi</groupId>
 					<artifactId>equinix</artifactId>
-					<version>0.27.2-alpha.1765320197+d4b1ddfa</version>
+					<version>(,1.0)</version>
 				</dependency>
 			</dependencies>
 

--- a/examples/network/ssh_user/python/requirements.txt
+++ b/examples/network/ssh_user/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.27.2-alpha.1765320197+d4b1ddfa
+pulumi_equinix==<1.0.0

--- a/examples/network/ssh_user/typescript/package.json
+++ b/examples/network/ssh_user/typescript/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.0.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@equinix-labs/pulumi-equinix": "0.27.2-alpha.1765320197+d4b1ddfa"
+		"@equinix-labs/pulumi-equinix": "<1.0.0"
 	}
 }

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -12,7 +12,7 @@ group = "com.equinix.pulumi"
 
 def resolvedVersion = System.getenv("PACKAGE_VERSION") ?:
     (project.version == "unspecified"
-         ? "0.27.2-alpha.1765320197+d4b1ddfa.dirty"
+         ? "0.27.2-alpha.1765395502+8d47e94b"
          : project.version)
 
 def signingKey = System.getenv("SIGNING_KEY")


### PR DESCRIPTION
For some reason, a previous `make build` removed our typical `< 1.0.0` version constraints in examples.  I re-ran `make build` and it restored the loose constraints.